### PR TITLE
ver 2.3.2: scope validator scoring state and migrate to targon workloads api

### DIFF
--- a/deploy/miner.py
+++ b/deploy/miner.py
@@ -6,15 +6,14 @@ import sys
 import time
 from hashlib import sha256
 from pathlib import Path
-from urllib.parse import urlparse
 from uuid import uuid4
 from dotenv import load_dotenv
 
 import bittensor as bt
 import httpx
 from targon.cli.auth import get_stored_key
-from targon.client.client import Client
-from targon.utils.config_parser import load_config, config_to_serverless_requests
+from targon.utils.config_parser import load_config
+from game.common.targon import extract_workload_uid, normalize_endpoint_url
 
 bt.logging.off()
 
@@ -25,6 +24,7 @@ DEPLOY_DIR = Path(__file__).resolve().parent
 PROFILES_DIR = DEPLOY_DIR / "profiles"
 META_REQUEST_TIMEOUT_SEC = 30
 META_POLL_INTERVAL_SEC = 3
+TARGON_WORKLOADS_API = "https://api.targon.com/tha/v2/workloads"
 
 
 def _ensure_typing_self() -> None:
@@ -73,45 +73,102 @@ def _get_api_key() -> str:
     raise RuntimeError("TARGON_API_KEY not set and no stored credentials found.")
 
 
-def _deploy_targon(config_path: Path) -> dict[str, str]:
+def _targon_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _build_workload_payload(container) -> dict:
+    replicas = container.replicas
+    min_replicas = 1
+    max_replicas = 1
+    target_concurrency = 100
+    container_concurrency = 100
+    if replicas is not None:
+        min_replicas = 0 if getattr(replicas, "scale_to_zero", False) else replicas.min
+        max_replicas = replicas.max
+        target_concurrency = replicas.target_concurrency
+        container_concurrency = replicas.container_concurrency
+
+    payload = {
+        "name": container.name,
+        "image": container.image,
+        "resource_name": container.resource or "cpu-small",
+        "type": "SERVERLESS",
+        "serverless_config": {
+            "min_replicas": min_replicas,
+            "max_replicas": max_replicas,
+            "initial_replicas": max(1, min_replicas),
+            "container_concurrency": container_concurrency,
+            "target_concurrency": target_concurrency,
+        },
+    }
+
+    if container.port:
+        payload["ports"] = [
+            {
+                "port": int(container.port),
+                "protocol": "TCP",
+                "routing": "DIRECT" if container.internal else "PROXIED",
+            }
+        ]
+    if container.env:
+        payload["envs"] = [
+            {"name": str(name), "value": str(value)}
+            for name, value in container.env.items()
+        ]
+    if container.command:
+        payload["commands"] = list(container.command)
+    if container.args:
+        payload["args"] = list(container.args)
+    if container.registry:
+        payload["registry_auth"] = {
+            "server": container.registry.server or "https://index.docker.io/v1/",
+            "username": container.registry.username or "",
+            "password": container.registry.password or "",
+        }
+
+    return payload
+
+
+def _deploy_targon(config_path: Path) -> dict[str, dict[str, str]]:
     _ensure_typing_self()
 
     config = load_config(config_path)
-    requests = config_to_serverless_requests(config)
-    if not requests:
+    containers = list(getattr(config, "containers", []) or [])
+    if not containers:
         raise RuntimeError(f"No containers defined in {config_path}")
 
     api_key = _get_api_key()
-    client = Client(api_key=api_key)
+    headers = _targon_headers(api_key)
 
-    async def _deploy():
-        responses: dict[str, str] = {}
-        for request in requests:
-            resource = await client.async_serverless.deploy_container(request)
-            responses[request.name] = resource.uid
-        return responses
+    responses: dict[str, dict[str, str]] = {}
+    with httpx.Client(timeout=60) as client:
+        for container in containers:
+            payload = _build_workload_payload(container)
+            create_resp = client.post(
+                TARGON_WORKLOADS_API,
+                headers=headers,
+                json=payload,
+            )
+            create_resp.raise_for_status()
+            created = create_resp.json()
+            workload_uid = str(created.get("uid") or "").strip()
+            if not workload_uid:
+                raise RuntimeError(
+                    f"Targon create workload response missing uid for {container.name}"
+                )
 
-    return client.run_async(_deploy)
+            deploy_resp = client.post(
+                f"{TARGON_WORKLOADS_API}/{workload_uid}/deploy",
+                headers=headers,
+            )
+            deploy_resp.raise_for_status()
+            responses[container.name] = {"uid": workload_uid}
 
-
-def _build_endpoint_url(endpoint_uid: str) -> str:
-    endpoint = endpoint_uid.strip().rstrip("/")
-    if endpoint.startswith(("http://", "https://")):
-        return endpoint
-    if "serverless.targon.com" in endpoint:
-        return f"https://{endpoint}"
-    return f"https://{endpoint}.serverless.targon.com"
-
-
-def _normalize_endpoint_uid(endpoint_uid: str) -> str:
-    endpoint = endpoint_uid.strip().rstrip("/")
-    if endpoint.startswith(("http://", "https://")):
-        host = urlparse(endpoint).netloc
-        if host:
-            endpoint = host
-    if endpoint.endswith(".serverless.targon.com"):
-        endpoint = endpoint.split(".serverless.targon.com", 1)[0]
-    return endpoint
+    return responses
 
 
 def _build_epistula_headers(hotkey: bt.Keypair, signed_for: str) -> dict[str, str]:
@@ -139,30 +196,47 @@ def _render_config_with_name(
 
 
 def _delete_targon_container(endpoint_uid: str) -> None:
-    _ensure_typing_self()
     api_key = _get_api_key()
-    client = Client(api_key=api_key)
-    resource_id = _normalize_endpoint_uid(endpoint_uid)
+    headers = _targon_headers(api_key)
+    workload_uid = extract_workload_uid(endpoint_uid)
+    with httpx.Client(timeout=30) as client:
+        response = client.delete(
+            f"{TARGON_WORKLOADS_API}/{workload_uid}", headers=headers
+        )
+        if response.status_code not in (200, 202, 204):
+            raise RuntimeError(
+                f"Failed deleting workload {workload_uid}: {response.status_code} {response.text}"
+            )
 
-    async def _delete():
-        return await client.async_serverless.delete_container(resource_id)
 
-    client.run_async(_delete)
+def _extract_access_url(state_payload: dict) -> str:
+    urls = state_payload.get("urls") or []
+    if not isinstance(urls, list):
+        return ""
+    for item in urls:
+        if isinstance(item, dict):
+            url = str(item.get("url") or "").strip()
+            if url:
+                return url.rstrip("/")
+    return ""
 
 
-def _wait_for_endpoint_ready(endpoint_uid: str, hotkey: bt.Keypair) -> bool:
-    base_url = _build_endpoint_url(endpoint_uid)
-    meta_url = f"{base_url}/meta"
+def _wait_for_endpoint_ready(workload_uid: str, hotkey: bt.Keypair) -> str | None:
+    api_key = _get_api_key()
+    workload_uid = extract_workload_uid(workload_uid)
+    headers = _targon_headers(api_key)
 
     with httpx.Client(timeout=META_REQUEST_TIMEOUT_SEC) as client:
         frame_idx = 0
         last_len = 0
         while True:
-            status_message = f"⏳ Waiting for endpoint readiness: {base_url}"
-            headers = _build_epistula_headers(hotkey, hotkey.ss58_address)
             try:
-                response = client.get(meta_url, headers=headers)
+                state_response = client.get(
+                    f"{TARGON_WORKLOADS_API}/{workload_uid}/state",
+                    headers=headers,
+                )
             except httpx.HTTPError as exc:
+                status_message = "⏳ waiting for workload state"
                 dots = "." * ((frame_idx % 3) + 1)
                 message = f"{status_message} {dots}"
                 last_len = _print_status_line(message, last_len)
@@ -170,52 +244,83 @@ def _wait_for_endpoint_ready(endpoint_uid: str, hotkey: bt.Keypair) -> bool:
                 time.sleep(META_POLL_INTERVAL_SEC)
                 continue
 
-            if response.status_code == 200:
+            status_message = f"⏳ waiting for workload state: {workload_uid}"
+            if state_response.status_code == 200:
                 try:
-                    payload = response.json()
+                    state_payload = state_response.json()
                 except ValueError:
+                    state_payload = {}
                     status_message = (
-                        "⏳ waiting for endpoint readiness: invalid JSON response"
+                        "⚠️ waiting for workload state: invalid JSON response"
                     )
                 else:
-                    sglang_process = payload.get("sglang_process") or {}
-                    returncode = sglang_process.get("returncode")
-                    running = sglang_process.get("running")
-                    if isinstance(returncode, int) and returncode < 0:
+                    workload_status = str(state_payload.get("status") or "").strip()
+                    access_url = _extract_access_url(state_payload)
+                    if workload_status and "fail" in workload_status.lower():
                         print()
                         print(
-                            "SGLang process crashed with returncode "
-                            f"{returncode}. Deleting deployed app..."
+                            f"❌ workload {workload_uid} entered status={workload_status}. "
+                            "Deleting deployed app."
+                        )
+                        _delete_targon_container(workload_uid)
+                        return None
+                    if access_url:
+                        meta_headers = _build_epistula_headers(
+                            hotkey, hotkey.ss58_address
                         )
                         try:
-                            _delete_targon_container(endpoint_uid)
-                        except Exception as exc:
-                            print(
-                                f"Failed to delete deployed app {endpoint_uid}: {exc}",
-                                file=sys.stderr,
+                            meta_response = client.get(
+                                f"{normalize_endpoint_url(access_url)}/meta",
+                                headers=meta_headers,
                             )
-                        return False
+                        except httpx.HTTPError:
+                            status_message = (
+                                f"⏳ waiting for endpoint readiness: {access_url}"
+                            )
+                        else:
+                            if meta_response.status_code == 200:
+                                try:
+                                    payload = meta_response.json()
+                                except ValueError:
+                                    status_message = "⚠️ waiting for endpoint readiness: invalid JSON response"
+                                else:
+                                    sglang_process = payload.get("sglang_process") or {}
+                                    returncode = sglang_process.get("returncode")
+                                    running = sglang_process.get("running")
+                                    if isinstance(returncode, int) and returncode < 0:
+                                        print()
+                                        print(
+                                            "❌ SGLang process crashed with returncode "
+                                            f"{returncode}. Deleting deployed app."
+                                        )
+                                        _delete_targon_container(workload_uid)
+                                        return None
 
-                    if running is True:
-                        status_message = "⏳ sglang is loading model"
-                    elif running is False:
-                        status_message = "⚠️ sglang process not running"
-                    else:
-                        status_message = "⏳ waiting for sglang process"
-                    if payload.get("sglang_port_open") is True:
-                        message = f"✅ Endpoint ready: {base_url}"
-                        _print_status_line(message, last_len)
-                        print()
-                        return True
-            else:
-                body = response.text.strip()
+                                    if payload.get("sglang_port_open") is True:
+                                        message = f"✅ Endpoint ready: {access_url}"
+                                        _print_status_line(message, last_len)
+                                        print()
+                                        return normalize_endpoint_url(access_url)
+
+                                    if running is True:
+                                        status_message = "⏳ SGLang is loading model"
+                                    elif running is False:
+                                        status_message = "⚠️ SGLang process not running"
+                                    else:
+                                        status_message = "⏳ waiting for SGLang process"
+                            else:
+                                status_message = (
+                                    f"⏳ waiting for endpoint readiness: {access_url}"
+                                )
+                    elif workload_status:
+                        status_message = f"⏳ workload status={workload_status}"
 
             dots = "." * ((frame_idx % 3) + 1)
             message = f"{status_message} {dots}"
             last_len = _print_status_line(message, last_len)
             frame_idx += 1
             time.sleep(META_POLL_INTERVAL_SEC)
-    return False
+    return None
 
 
 def _print_status_line(message: str, last_len: int) -> int:
@@ -370,19 +475,24 @@ def main() -> int:
         print(f"Failed to deploy via Targon: {exc}", file=sys.stderr)
         return 1
 
-    endpoint_uid = deployed.get(container_name)
-    if endpoint_uid is None:
+    deployed_info = deployed.get(container_name)
+    if deployed_info is None:
         if len(deployed) == 1:
-            endpoint_uid = next(iter(deployed.values()))
+            deployed_info = next(iter(deployed.values()))
         else:
             print(
                 f"Expected container '{container_name}' but got {sorted(deployed)}",
                 file=sys.stderr,
             )
             return 1
+    workload_uid = str((deployed_info or {}).get("uid") or "").strip()
+    if not workload_uid:
+        print("Failed to determine workload uid from Targon response.", file=sys.stderr)
+        return 1
 
     try:
-        if not _wait_for_endpoint_ready(endpoint_uid, wallet.hotkey):
+        endpoint_url = _wait_for_endpoint_ready(workload_uid, wallet.hotkey)
+        if not endpoint_url:
             return 1
     except Exception as exc:
         print(f"Failed to confirm endpoint readiness: {exc}", file=sys.stderr)
@@ -394,14 +504,14 @@ def main() -> int:
             network=args.network,
             netuid=args.netuid,
             competition_keys=competition_keys,
-            endpoint_uid=endpoint_uid,
+            endpoint_uid=endpoint_url,
             period=args.commit_period,
         )
     except Exception as exc:
         print(f"Failed to commit endpoint: {exc}", file=sys.stderr)
         return 1
 
-    print(f"✅ Successfully committed endpoint {endpoint_uid} to chain.")
+    print(f"✅ Successfully committed endpoint {endpoint_url} to chain.")
     return 0
 
 

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the module.
-__version__ = "2.3.1"
+__version__ = "2.3.2"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/game/base/validator.py
+++ b/game/base/validator.py
@@ -576,14 +576,19 @@ class BaseValidatorNeuron(BaseNeuron):
 
         competition = self.competition
         comp_value = competition.value
+        validator_hotkey = self.wallet.hotkey.ss58_address
         use_generic_scores = (
             comp_value != "codenames"
             and getattr(self, "generic_store", None) is not None
         )
         latest_ts = (
-            self.generic_store.latest_timestamp(comp_value)
+            self.generic_store.latest_timestamp(
+                comp_value, validator_hotkey=validator_hotkey
+            )
             if use_generic_scores
-            else self.score_store.latest_scores_all_timestamp()
+            else self.score_store.latest_scores_all_timestamp(
+                validator_hotkey=validator_hotkey
+            )
         )
 
         age_seconds = now - latest_ts
@@ -599,24 +604,27 @@ class BaseValidatorNeuron(BaseNeuron):
         if use_generic_scores:
             avg_scores, total_scores, counts = (
                 self.generic_store.window_average_scores_by_hotkey(
-                    comp_value, since_ts, end_ts
+                    comp_value, since_ts, end_ts, validator_hotkey=validator_hotkey
                 )
             )
             win_counts, loss_counts = self.generic_store.win_loss_counts_in_window(
-                comp_value, since_ts, end_ts
+                comp_value, since_ts, end_ts, validator_hotkey=validator_hotkey
             )
             observer_counts = {}
         else:
             avg_scores, total_scores, counts = (
                 self.score_store.window_average_scores_by_hotkey(
-                    comp_value, since_ts, end_ts
+                    comp_value, since_ts, end_ts, validator_hotkey=validator_hotkey
                 )
             )
             win_counts, loss_counts = self.score_store.win_loss_counts_in_window(
-                comp_value, since_ts, end_ts
+                comp_value, since_ts, end_ts, validator_hotkey=validator_hotkey
             )
             observer_counts = self.score_store.observer_records_in_window(
-                comp_value, since_ts, end_ts
+                comp_value,
+                since_ts,
+                end_ts,
+                validator_hotkey=validator_hotkey,
             )
         hotkeys_with_minimum_stake = [
             self.metagraph.hotkeys[uid]
@@ -673,9 +681,16 @@ class BaseValidatorNeuron(BaseNeuron):
         }
 
         comp_games = (
-            self.generic_store.games_in_window(comp_value, since_ts, end_ts)
+            self.generic_store.games_in_window(
+                comp_value, since_ts, end_ts, validator_hotkey=validator_hotkey
+            )
             if use_generic_scores
-            else self.score_store.games_in_window(since_ts, end_ts, comp_value)
+            else self.score_store.games_in_window(
+                since_ts,
+                end_ts,
+                comp_value,
+                validator_hotkey=validator_hotkey,
+            )
         )
         if comp_games < 30:
             self._log_competition_scores(

--- a/game/base/validator.py
+++ b/game/base/validator.py
@@ -281,8 +281,6 @@ class BaseValidatorNeuron(BaseNeuron):
         try:
             if getattr(self.config.subtensor, "network", None) == "test":
                 self.backend_base = "https://dev-backend.shiftlayer.ai"
-            if getattr(self.config, "competition", None) == "twentyq":
-                self.backend_base = "https://dev-backend.shiftlayer.ai"
         except AttributeError:
             pass
         bt.logging.info(f"Using backend: {self.backend_base}")

--- a/game/common/targon.py
+++ b/game/common/targon.py
@@ -1,0 +1,34 @@
+"""Helpers for working with Targon endpoint identifiers and URLs."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+
+def normalize_endpoint_url(endpoint: str) -> str:
+    value = (endpoint or "").strip().rstrip("/")
+    if not value:
+        return ""
+    if value.startswith(("http://", "https://")):
+        return value
+    if value.endswith(".serverless.targon.com") or value.endswith(".caas.targon.com"):
+        return f"https://{value}"
+    if value.startswith("wrk-"):
+        return f"https://{value}.serverless.targon.com"
+    return f"https://{value}.serverless.targon.com"
+
+
+def extract_workload_uid(endpoint: str) -> str:
+    value = (endpoint or "").strip().rstrip("/")
+    if not value:
+        return ""
+    if value.startswith(("http://", "https://")):
+        host = urlparse(value).netloc or ""
+    else:
+        host = value
+
+    if host.endswith(".serverless.targon.com"):
+        return host.split(".serverless.targon.com", 1)[0]
+    if host.endswith(".caas.targon.com"):
+        return host.split(".caas.targon.com", 1)[0]
+    return host

--- a/game/plugins/twentyq/validator_runner.py
+++ b/game/plugins/twentyq/validator_runner.py
@@ -17,6 +17,7 @@ from openai import OpenAI
 
 from game.common.epistula import generate_header
 from game.common.misc import extract_json
+from game.common.targon import normalize_endpoint_url
 from game.core.commitment_reader import read_endpoints
 from game.core.interfaces import AttemptResult, SessionResult
 from game.plugins.codenames.game_types import Competition
@@ -732,11 +733,4 @@ class TwentyQValidatorRunner:
 
     @staticmethod
     def _endpoint_base_url(endpoint: str) -> str:
-        endpoint = (endpoint or "").strip().rstrip("/")
-        if endpoint.startswith(("http://", "https://")):
-            if endpoint.endswith(".serverless.targon.com"):
-                return endpoint
-            return endpoint
-        if ".serverless.targon.com" in endpoint:
-            return f"https://{endpoint}"
-        return f"https://{endpoint}.serverless.targon.com"
+        return normalize_endpoint_url(endpoint)

--- a/game/providers/judge/chutes_ai.py
+++ b/game/providers/judge/chutes_ai.py
@@ -105,7 +105,11 @@ class ChutesAIJudge:
         ]
 
         try:
-            model_candidates = [self.model, "openai/gpt-oss-120b-TEE"]
+            model_candidates = [
+                self.model,
+                "openai/gpt-oss-20b-TEE",
+                "openai/gpt-oss-120b-TEE",
+            ]
             # Keep order while deduplicating.
             deduped_models = []
             for candidate in model_candidates:
@@ -143,6 +147,12 @@ class ChutesAIJudge:
                     last_err = err
                     bt.logging.warning(
                         f"[20Q] Judge model not found: {candidate_model}; trying next."
+                    )
+                    continue
+                except Exception as err:  # noqa: BLE001
+                    last_err = err
+                    bt.logging.warning(
+                        f"[20Q] Judge model failed: {candidate_model}; error={err}; trying next."
                     )
                     continue
 

--- a/game/providers/targon_client.py
+++ b/game/providers/targon_client.py
@@ -3,6 +3,7 @@ import bittensor as bt
 import asyncio
 import aiohttp
 from game.common.epistula import generate_header
+from game.common.targon import extract_workload_uid, normalize_endpoint_url
 from game import __image_hash__
 
 
@@ -20,7 +21,7 @@ async def get_metadata(self, endpoint: str, hotkey: str) -> dict:
         dict: The metadata dictionary if successful, empty dict otherwise.
     """
     try:
-        url = f"https://{endpoint}.serverless.targon.com/meta"
+        url = f"{normalize_endpoint_url(endpoint)}/meta"
         headers = generate_header(self.wallet.hotkey, b"", hotkey)
         async with aiohttp.ClientSession() as session:
             async with session.get(url, headers=headers) as response:
@@ -43,35 +44,56 @@ async def _check_image_hash(self, endpoint: str, uid: int | None = None) -> bool
     """
     try:
         url = f"https://api.targon.com/tha/v2/workloads/verify"
+        workload_uid = extract_workload_uid(endpoint)
         headers = {
             "Authorization": f"Bearer {os.getenv('TARGON_API_KEY')}",
             "Content-Type": "application/json",
         }
         async with aiohttp.ClientSession() as session:
-            async with session.post(
-                url,
-                headers=headers,
-                json={"url": f"https://{endpoint}.serverless.targon.com"},
-            ) as response:
-                if response.status != 200:
-                    body = await response.text()
-                    uid_text = "?" if uid is None else str(uid)
-                    _log_yellow_info(f"{uid_text} {endpoint}: {response.status} {body}")
-                    return False
-                try:
-                    data = await response.json()
-                except aiohttp.ContentTypeError:
-                    body = await response.text()
-                    uid_text = "?" if uid is None else str(uid)
-                    _log_yellow_info(f"{uid_text} {endpoint}: invalid_json {body}")
-                    return False
-                if "image_hash" in data:
-                    if data.get("image_hash") == __image_hash__:
-                        return True
-                    bt.logging.info(
-                        f"Image hash mismatch for endpoint {endpoint}: "
-                        f"expected {__image_hash__}, got {data.get('image_hash')}"
-                    )
+            payloads = [{"uid": workload_uid, "digest": __image_hash__}]
+            normalized_url = normalize_endpoint_url(endpoint)
+            if workload_uid.startswith("serv-"):
+                payloads.append({"url": normalized_url})
+
+            response = None
+            data = None
+            for payload in payloads:
+                async with session.post(
+                    url,
+                    headers=headers,
+                    json=payload,
+                ) as current_response:
+                    response = current_response
+                    if current_response.status != 200:
+                        continue
+                    try:
+                        data = await current_response.json()
+                    except aiohttp.ContentTypeError:
+                        body = await current_response.text()
+                        uid_text = "?" if uid is None else str(uid)
+                        _log_yellow_info(f"{uid_text} {endpoint}: invalid_json {body}")
+                        return False
+                    break
+
+            if response is None or response.status != 200:
+                body = await response.text() if response is not None else "no_response"
+                uid_text = "?" if uid is None else str(uid)
+                _log_yellow_info(
+                    f"{uid_text} {endpoint}: {response.status if response else 'n/a'} {body}"
+                )
+                return False
+
+            if "verified" in (data or {}):
+                if bool(data.get("verified")):
+                    return True
+            elif "image_hash" in (data or {}):
+                if data.get("image_hash") == __image_hash__:
+                    return True
+
+            bt.logging.info(
+                f"Image digest verification failed for endpoint {endpoint}: "
+                f"workload_uid={workload_uid}"
+            )
         return False
     except Exception as e:
         uid_text = "?" if uid is None else str(uid)

--- a/game/providers/targon_client.py
+++ b/game/providers/targon_client.py
@@ -42,7 +42,7 @@ async def _check_image_hash(self, endpoint: str, uid: int | None = None) -> bool
         bool: True if the image hash matches, False otherwise.
     """
     try:
-        url = f"https://api.targon.com/v1/deployments/image-hash"
+        url = f"https://api.targon.com/tha/v2/workloads/verify"
         headers = {
             "Authorization": f"Bearer {os.getenv('TARGON_API_KEY')}",
             "Content-Type": "application/json",
@@ -56,18 +56,14 @@ async def _check_image_hash(self, endpoint: str, uid: int | None = None) -> bool
                 if response.status != 200:
                     body = await response.text()
                     uid_text = "?" if uid is None else str(uid)
-                    _log_yellow_info(
-                        f"{uid_text} {endpoint}: {response.status} {body}"
-                    )
+                    _log_yellow_info(f"{uid_text} {endpoint}: {response.status} {body}")
                     return False
                 try:
                     data = await response.json()
                 except aiohttp.ContentTypeError:
                     body = await response.text()
                     uid_text = "?" if uid is None else str(uid)
-                    _log_yellow_info(
-                        f"{uid_text} {endpoint}: invalid_json {body}"
-                    )
+                    _log_yellow_info(f"{uid_text} {endpoint}: invalid_json {body}")
                     return False
                 if "image_hash" in data:
                     if data.get("image_hash") == __image_hash__:

--- a/game/storage/store.py
+++ b/game/storage/store.py
@@ -132,25 +132,35 @@ class GenericStore:
             )
 
     def window_average_scores_by_hotkey(
-        self, competition_code: str, since_ts: float, end_ts: float
+        self,
+        competition_code: str,
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: str | None = None,
     ):
         query = """
             SELECT a.miner_hotkey, AVG(a.score), SUM(a.score), COUNT(*)
             FROM attempts a
             JOIN sessions s ON s.session_id = a.session_id
             WHERE s.competition_code = ? AND a.ended_at >= ? AND a.ended_at < ?
-            GROUP BY a.miner_hotkey
         """
-        rows = self.conn.execute(
-            query, (competition_code, int(since_ts), int(end_ts))
-        ).fetchall()
+        params = [competition_code, int(since_ts), int(end_ts)]
+        if validator_hotkey:
+            query += " AND s.validator_hotkey = ?"
+            params.append(validator_hotkey)
+        query += " GROUP BY a.miner_hotkey"
+        rows = self.conn.execute(query, tuple(params)).fetchall()
         avg_scores = {hotkey: float(avg or 0.0) for hotkey, avg, _, _ in rows}
         total_scores = {hotkey: float(total or 0.0) for hotkey, _, total, _ in rows}
         counts = {hotkey: float(count or 0.0) for hotkey, _, _, count in rows}
         return avg_scores, total_scores, counts
 
     def win_loss_counts_in_window(
-        self, competition_code: str, since_ts: float, end_ts: float
+        self,
+        competition_code: str,
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: str | None = None,
     ) -> tuple[Dict[str, int], Dict[str, int]]:
         query = """
             SELECT
@@ -160,41 +170,64 @@ class GenericStore:
             FROM attempts a
             JOIN sessions s ON s.session_id = a.session_id
             WHERE s.competition_code = ? AND a.ended_at >= ? AND a.ended_at < ?
-            GROUP BY a.miner_hotkey
         """
-        rows = self.conn.execute(
-            query, (competition_code, int(since_ts), int(end_ts))
-        ).fetchall()
+        params = [competition_code, int(since_ts), int(end_ts)]
+        if validator_hotkey:
+            query += " AND s.validator_hotkey = ?"
+            params.append(validator_hotkey)
+        query += " GROUP BY a.miner_hotkey"
+        rows = self.conn.execute(query, tuple(params)).fetchall()
         wins = {str(hotkey): int(win_count or 0) for hotkey, win_count, _ in rows}
         losses = {str(hotkey): int(loss_count or 0) for hotkey, _, loss_count in rows}
         return wins, losses
 
     def games_in_window(
-        self, competition_code: str, since_ts: float, end_ts: float
+        self,
+        competition_code: str,
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: str | None = None,
     ) -> int:
-        row = self.conn.execute(
-            """
+        query = """
             SELECT COUNT(DISTINCT s.session_id)
             FROM sessions s
             WHERE s.competition_code = ? AND s.ended_at >= ? AND s.ended_at < ?
-            """,
-            (competition_code, int(since_ts), int(end_ts)),
-        ).fetchone()
+        """
+        params = [competition_code, int(since_ts), int(end_ts)]
+        if validator_hotkey:
+            query += " AND s.validator_hotkey = ?"
+            params.append(validator_hotkey)
+        row = self.conn.execute(query, tuple(params)).fetchone()
         return int(row[0] or 0) if row else 0
 
-    def latest_timestamp(self, competition_code: Optional[str] = None) -> int:
+    def latest_timestamp(
+        self,
+        competition_code: Optional[str] = None,
+        validator_hotkey: str | None = None,
+    ) -> int:
         if competition_code is None:
-            row = self.conn.execute("SELECT MAX(ended_at) FROM attempts").fetchone()
+            query = """
+                SELECT MAX(a.ended_at)
+                FROM attempts a
+                JOIN sessions s ON s.session_id = a.session_id
+            """
+            params: list[object] = []
+            if validator_hotkey:
+                query += " WHERE s.validator_hotkey = ?"
+                params.append(validator_hotkey)
+            row = self.conn.execute(query, tuple(params)).fetchone()
         else:
-            row = self.conn.execute(
-                """
+            query = """
                 SELECT MAX(a.ended_at)
                 FROM attempts a
                 JOIN sessions s ON s.session_id = a.session_id
                 WHERE s.competition_code = ?
-                """,
-                (competition_code,),
-            ).fetchone()
+            """
+            params: list[object] = [competition_code]
+            if validator_hotkey:
+                query += " AND s.validator_hotkey = ?"
+                params.append(validator_hotkey)
+            row = self.conn.execute(query, tuple(params)).fetchone()
         return int(row[0] or 0) if row else 0
 
     def iter_attempts(self) -> Iterable[tuple]:

--- a/game/validator/forward.py
+++ b/game/validator/forward.py
@@ -26,6 +26,7 @@ import httpx
 from game.protocol import GameChatMessage, GameSynapse, GameSynapseOutput
 from game.common.epistula import generate_header
 from game.common.misc import extract_json
+from game.common.targon import normalize_endpoint_url
 from game.plugins.codenames.prompt_loader import (
     get_op_sys_prompt,
     get_spy_sys_prompt,
@@ -272,7 +273,7 @@ async def get_tvm_response(
             http_client = httpx.Client(event_hooks={"request": [_epistula_hook]})
             client = OpenAI(
                 api_key="",
-                base_url=f"https://{endpoint}.serverless.targon.com/v1",
+                base_url=f"{normalize_endpoint_url(endpoint)}/v1",
                 http_client=http_client,
             )
             result = await asyncio.wait_for(
@@ -729,7 +730,9 @@ async def forward(self):
             bt.logging.info(f"Guessed cards: {guesses}")
             if guesses is None or len(guesses) == 0:
                 invalid_respond_counts[to_uid] += 1
-                bt.logging.info(f"⚠️ No guesses '{guesses}' provided by miner {to_uid}.")
+                bt.logging.info(
+                    f"⚠️ No guesses '{guesses}' provided by miner {to_uid}."
+                )
                 if invalid_respond_counts[to_uid] < 2:
                     # Switch turn to the other team
                     game_state.chatHistory.append(

--- a/game/validator/score_store.py
+++ b/game/validator/score_store.py
@@ -426,10 +426,16 @@ class ScoreStore:
         losses = {str(hotkey): int(loss_count or 0) for hotkey, _, loss_count in rows}
         return wins, losses
 
-    def max_scores_all_id(self) -> int:
+    def max_scores_all_id(self, validator_hotkey: Optional[str] = None) -> int:
         with self._lock:
             cur = self.conn.cursor()
-            cur.execute("SELECT MAX(id) FROM scores_all")
+            if validator_hotkey:
+                cur.execute(
+                    "SELECT MAX(id) FROM scores_all WHERE validator = ?",
+                    (validator_hotkey,),
+                )
+            else:
+                cur.execute("SELECT MAX(id) FROM scores_all")
             row = cur.fetchone()
             cur.close()
         if not row or row[0] is None:

--- a/game/validator/score_store.py
+++ b/game/validator/score_store.py
@@ -278,7 +278,11 @@ class ScoreStore:
         return rows
 
     def window_average_scores_by_hotkey(
-        self, competition: Optional[str], since_ts: float, end_ts: float
+        self,
+        competition: Optional[str],
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: Optional[str] = None,
     ) -> Dict[str, float]:
         avg_scores: Dict[str, float] = defaultdict(float)
         total_scores: Dict[str, float] = defaultdict(float)
@@ -289,8 +293,11 @@ class ScoreStore:
             query = """
                 SELECT hotkey, SUM(score) * 1.0 / COUNT(*), SUM(score), COUNT(*) FROM miner_records
                 WHERE ts >= ? AND ts < ? AND competition = ?
-                GROUP BY hotkey
             """
+            if validator_hotkey:
+                query += " AND validator = ?"
+                params.append(validator_hotkey)
+            query += " GROUP BY hotkey"
             cur.execute(query, tuple(params))
             rows = cur.fetchall()
             for row in rows:
@@ -335,7 +342,11 @@ class ScoreStore:
         )
 
     def observer_records_in_window(
-        self, competition: str, since_ts: float, end_ts: float
+        self,
+        competition: str,
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: Optional[str] = None,
     ) -> Dict[str, int]:
         """Return counts of games where each hotkey participated only as an observer.
 
@@ -357,9 +368,19 @@ class ScoreStore:
                     AND mr.competition = ?
                     AND sa.competition = mr.competition
                     AND mr.hotkey NOT IN (sa.rs, sa.ro, sa.bs, sa.bo)
+                    AND (? = '' OR mr.validator = ?)
+                    AND (? = '' OR sa.validator = ?)
                 GROUP BY mr.hotkey
                 """,
-                (int(since_ts), int(end_ts), competition),
+                (
+                    int(since_ts),
+                    int(end_ts),
+                    competition,
+                    validator_hotkey or "",
+                    validator_hotkey or "",
+                    validator_hotkey or "",
+                    validator_hotkey or "",
+                ),
             )
             rows = cur.fetchall()
             cur.close()
@@ -367,7 +388,11 @@ class ScoreStore:
         return {hotkey: int(count) for hotkey, count in rows}
 
     def win_loss_counts_in_window(
-        self, competition: str, since_ts: float, end_ts: float
+        self,
+        competition: str,
+        since_ts: float,
+        end_ts: float,
+        validator_hotkey: Optional[str] = None,
     ) -> tuple[Dict[str, int], Dict[str, int]]:
         """Return per-hotkey win/loss counts from miner_records in the window.
 
@@ -383,9 +408,16 @@ class ScoreStore:
                     SUM(CASE WHEN score <= 0 THEN 1 ELSE 0 END) AS losses
                 FROM miner_records
                 WHERE ts >= ? AND ts < ? AND competition = ?
+                  AND (? = '' OR validator = ?)
                 GROUP BY hotkey
                 """,
-                (int(since_ts), int(end_ts), competition),
+                (
+                    int(since_ts),
+                    int(end_ts),
+                    competition,
+                    validator_hotkey or "",
+                    validator_hotkey or "",
+                ),
             )
             rows = cur.fetchall()
             cur.close()
@@ -404,16 +436,30 @@ class ScoreStore:
             return 0
         return int(row[0])
 
-    def latest_scores_all_timestamp(self) -> int:
+    def latest_scores_all_timestamp(
+        self, validator_hotkey: Optional[str] = None
+    ) -> int:
         with self._lock:
             cur = self.conn.cursor()
-            cur.execute("SELECT MAX(ended_at) FROM scores_all")
+            if validator_hotkey:
+                cur.execute(
+                    "SELECT MAX(ended_at) FROM scores_all WHERE validator = ?",
+                    (validator_hotkey,),
+                )
+            else:
+                cur.execute("SELECT MAX(ended_at) FROM scores_all")
             row = cur.fetchone()
             if not row or row[0] is None:
                 cur.execute("SELECT MAX(ended_at) FROM scores")
                 row = cur.fetchone()
             if not row or row[0] is None:
-                cur.execute("SELECT MAX(ts) FROM miner_records")
+                if validator_hotkey:
+                    cur.execute(
+                        "SELECT MAX(ts) FROM miner_records WHERE validator = ?",
+                        (validator_hotkey,),
+                    )
+                else:
+                    cur.execute("SELECT MAX(ts) FROM miner_records")
                 row = cur.fetchone()
             cur.close()
         if not row or row[0] is None:
@@ -421,7 +467,11 @@ class ScoreStore:
         return int(row[0])
 
     def games_in_window(
-        self, since_ts: float, end_ts: float, competition: Optional[str] = None
+        self,
+        since_ts: float,
+        end_ts: float,
+        competition: Optional[str] = None,
+        validator_hotkey: Optional[str] = None,
     ) -> int:
         with self._lock:
             cur = self.conn.cursor()
@@ -432,6 +482,9 @@ class ScoreStore:
             if competition is not None:
                 query += " AND competition = ?"
                 params.append(competition)
+            if validator_hotkey:
+                query += " AND validator = ?"
+                params.append(validator_hotkey)
             cur.execute(query, tuple(params))
             row = cur.fetchone()
             if row and row[0]:
@@ -439,14 +492,16 @@ class ScoreStore:
             else:
                 count = 0
                 if competition is not None:
-                    cur.execute(
-                        """
+                    fallback_query = """
                         SELECT COUNT(DISTINCT room_id)
                         FROM miner_records
                         WHERE ts >= ? AND ts < ? AND competition = ?
-                        """,
-                        (int(since_ts), int(end_ts), competition),
-                    )
+                    """
+                    fallback_params = [int(since_ts), int(end_ts), competition]
+                    if validator_hotkey:
+                        fallback_query += " AND validator = ?"
+                        fallback_params.append(validator_hotkey)
+                    cur.execute(fallback_query, tuple(fallback_params))
                     row2 = cur.fetchone()
                     if row2 and row2[0]:
                         count = int(row2[0])

--- a/tests/unit/common/test_targon.py
+++ b/tests/unit/common/test_targon.py
@@ -1,0 +1,27 @@
+from game.common.targon import extract_workload_uid, normalize_endpoint_url
+
+
+def test_normalize_endpoint_url_supports_old_and_new_targon_shapes():
+    assert (
+        normalize_endpoint_url("serv-u-123")
+        == "https://serv-u-123.serverless.targon.com"
+    )
+    assert normalize_endpoint_url("wrk-abc") == "https://wrk-abc.caas.targon.com"
+    assert (
+        normalize_endpoint_url("wrk-abc.caas.targon.com")
+        == "https://wrk-abc.caas.targon.com"
+    )
+    assert (
+        normalize_endpoint_url("https://wrk-abc.caas.targon.com")
+        == "https://wrk-abc.caas.targon.com"
+    )
+
+
+def test_extract_workload_uid_supports_old_and_new_targon_shapes():
+    assert extract_workload_uid("serv-u-123") == "serv-u-123"
+    assert extract_workload_uid("wrk-abc") == "wrk-abc"
+    assert extract_workload_uid("wrk-abc.caas.targon.com") == "wrk-abc"
+    assert extract_workload_uid("https://wrk-abc.caas.targon.com") == "wrk-abc"
+    assert (
+        extract_workload_uid("https://serv-u-123.serverless.targon.com") == "serv-u-123"
+    )

--- a/tests/unit/providers/test_chutes_ai_judge.py
+++ b/tests/unit/providers/test_chutes_ai_judge.py
@@ -46,3 +46,52 @@ def test_chutes_ai_uses_dataset_properties_in_fallback():
         )
     )
     assert answer == "no"
+
+
+def test_chutes_ai_tries_alternative_model_before_heuristic(monkeypatch):
+    calls = []
+
+    class _Message:
+        def __init__(self, content):
+            self.content = content
+            self.reasoning_content = ""
+            self.reasoning = ""
+
+    class _Choice:
+        def __init__(self, content):
+            self.finish_reason = "stop"
+            self.message = _Message(content)
+
+    class _Result:
+        def __init__(self, content):
+            self.choices = [_Choice(content)]
+
+    class _Completions:
+        def create(self, **kwargs):
+            model = kwargs["model"]
+            calls.append(model)
+            if model == "openai/gpt-oss-120b-TEE":
+                raise RuntimeError("Error code: 429")
+            if model == "openai/gpt-oss-20b-TEE":
+                return _Result('{"answer":"yes","reasoning":"fallback model worked"}')
+            raise AssertionError(f"unexpected model {model}")
+
+    class _Chat:
+        def __init__(self):
+            self.completions = _Completions()
+
+    class _FakeOpenAI:
+        def __init__(self, *args, **kwargs):
+            self.chat = _Chat()
+
+    monkeypatch.setattr("game.providers.judge.chutes_ai.OpenAI", _FakeOpenAI)
+
+    judge = ChutesAIJudge(
+        api_key="test-key",
+        base_url="https://llm.chutes.ai/v1",
+        model="openai/gpt-oss-120b-TEE",
+    )
+    answer = asyncio.run(judge.answer(secret="apple", question="Is it a fruit?"))
+
+    assert calls == ["openai/gpt-oss-120b-TEE", "openai/gpt-oss-20b-TEE"]
+    assert answer == "yes"

--- a/tests/unit/storage/test_generic_store.py
+++ b/tests/unit/storage/test_generic_store.py
@@ -54,3 +54,75 @@ def test_generic_store_aggregates_attempt_scores(tmp_path):
     assert counts["miner-1"] == 1.0
     assert wins["miner-1"] == 1
     assert losses["miner-2"] == 1
+
+
+def test_generic_store_filters_by_validator_hotkey(tmp_path):
+    store = GenericStore(str(tmp_path / "generic.db"))
+    store.init()
+
+    store.upsert_session(
+        {
+            "session_id": "room-1",
+            "game_code": "twentyq",
+            "competition_code": "twentyq",
+            "validator_hotkey": "validator-1",
+            "status": "completed",
+            "started_at": 100,
+            "ended_at": 120,
+            "metadata_json": "{}",
+        }
+    )
+    store.upsert_attempt(
+        {
+            "attempt_id": "room-1:miner-1",
+            "session_id": "room-1",
+            "miner_hotkey": "miner-1",
+            "status": "solved",
+            "score": 1.0,
+            "started_at": 100,
+            "ended_at": 120,
+            "summary_json": "{}",
+        }
+    )
+
+    store.upsert_session(
+        {
+            "session_id": "room-2",
+            "game_code": "twentyq",
+            "competition_code": "twentyq",
+            "validator_hotkey": "validator-2",
+            "status": "completed",
+            "started_at": 130,
+            "ended_at": 150,
+            "metadata_json": "{}",
+        }
+    )
+    store.upsert_attempt(
+        {
+            "attempt_id": "room-2:miner-1",
+            "session_id": "room-2",
+            "miner_hotkey": "miner-1",
+            "status": "solved",
+            "score": 0.0,
+            "started_at": 130,
+            "ended_at": 150,
+            "summary_json": "{}",
+        }
+    )
+
+    avg_scores, total_scores, counts = store.window_average_scores_by_hotkey(
+        "twentyq", 0, 1_000, validator_hotkey="validator-1"
+    )
+    wins, losses = store.win_loss_counts_in_window(
+        "twentyq", 0, 1_000, validator_hotkey="validator-1"
+    )
+
+    assert (
+        store.games_in_window("twentyq", 0, 1_000, validator_hotkey="validator-1") == 1
+    )
+    assert store.latest_timestamp("twentyq", validator_hotkey="validator-1") == 120
+    assert avg_scores["miner-1"] == 1.0
+    assert total_scores["miner-1"] == 1.0
+    assert counts["miner-1"] == 1.0
+    assert wins["miner-1"] == 1
+    assert losses["miner-1"] == 0

--- a/tests/unit/storage/test_score_store_twentyq.py
+++ b/tests/unit/storage/test_score_store_twentyq.py
@@ -34,6 +34,76 @@ def test_upload_scores_persists_fractional_values(tmp_path):
     assert counts["miner-1"] == 1.0
 
 
+def test_legacy_score_queries_filter_by_validator(tmp_path):
+    db_path = str(tmp_path / "scores.db")
+    store = ScoreStore(
+        db_path,
+        backend_url="",
+        fetch_url=None,
+        signer=lambda: {"X-Validator-Hotkey": "validator-a"},
+    )
+    store.init()
+
+    store._upsert_scores_all(
+        [
+            {
+                "id": 1,
+                "room_id": "room-a",
+                "competition": "codenames",
+                "validator": "validator-a",
+                "rs": "miner-1",
+                "ro": "miner-2",
+                "bs": "miner-3",
+                "bo": "miner-4",
+                "started_at": 100,
+                "ended_at": 120,
+                "score_rs": 1.0,
+                "score_ro": 0.0,
+                "score_bs": 0.0,
+                "score_bo": 0.0,
+                "participants": ["miner-1", "miner-2", "miner-3", "miner-4"],
+            },
+            {
+                "id": 2,
+                "room_id": "room-b",
+                "competition": "codenames",
+                "validator": "validator-b",
+                "rs": "miner-1",
+                "ro": "miner-2",
+                "bs": "miner-3",
+                "bo": "miner-4",
+                "started_at": 130,
+                "ended_at": 150,
+                "score_rs": 0.0,
+                "score_ro": 1.0,
+                "score_bs": 0.0,
+                "score_bo": 0.0,
+                "participants": ["miner-1", "miner-2", "miner-3", "miner-4"],
+            },
+        ]
+    )
+
+    avg_scores, total_scores, counts = store.window_average_scores_by_hotkey(
+        "codenames", 0, 1_000, validator_hotkey="validator-a"
+    )
+    wins, losses = store.win_loss_counts_in_window(
+        "codenames", 0, 1_000, validator_hotkey="validator-a"
+    )
+
+    assert store.max_scores_all_id(validator_hotkey="validator-a") == 1
+    assert store.max_scores_all_id(validator_hotkey="validator-b") == 2
+    assert store.latest_scores_all_timestamp(validator_hotkey="validator-a") == 120
+    assert (
+        store.games_in_window(0, 1_000, "codenames", validator_hotkey="validator-a")
+        == 1
+    )
+    assert avg_scores["miner-1"] == 1.0
+    assert total_scores["miner-2"] == 0.0
+    assert counts["miner-1"] == 1.0
+    assert wins["miner-1"] == 1
+    assert losses["miner-2"] == 1
+
+
 def test_sync_scores_all_populates_generic_store_for_twentyq(tmp_path):
     db_path = str(tmp_path / "scores.db")
     generic_store = GenericStore(db_path)

--- a/tests/unit/test_validator_main_mode.py
+++ b/tests/unit/test_validator_main_mode.py
@@ -1,0 +1,43 @@
+from game.base.validator import BaseValidatorNeuron
+
+
+def test_base_validator_argv_strips_competition_flag():
+    argv = [
+        "neurons/validator.py",
+        "--wallet.name",
+        "owner",
+        "--competition",
+        "main",
+        "--logging.info",
+    ]
+
+    assert BaseValidatorNeuron._base_validator_argv(argv) == [
+        "neurons/validator.py",
+        "--wallet.name",
+        "owner",
+        "--logging.info",
+    ]
+
+
+def test_base_validator_argv_strips_competition_equals_flag():
+    argv = [
+        "neurons/validator.py",
+        "--wallet.name",
+        "owner",
+        "--competition=twentyq",
+        "--logging.info",
+    ]
+
+    assert BaseValidatorNeuron._base_validator_argv(argv) == [
+        "neurons/validator.py",
+        "--wallet.name",
+        "owner",
+        "--logging.info",
+    ]
+
+
+def test_main_mode_competition_codes_include_all_competitions():
+    assert BaseValidatorNeuron._competition_codes_for_main() == [
+        "codenames",
+        "twentyq",
+    ]


### PR DESCRIPTION
## Included Changes

- filter score aggregation by the current validator hotkey
- remove the unconditional `twentyq -> dev-backend` override
- chore: update targon image hash check url
- fix(targon): migrate deploy and endpoint handling to workloads api
- fix(twentyq): retry chutes judge with gpt-oss-20b on capacity errors
- bump package version to `2.3.2`
