### PR TITLE
SuperMario subnet integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ python deploy/miner.py \
   --hotkey default
 ```
 
+Deploy only for SuperMario:
+
+```bash
+python deploy/miner.py \
+  --competition supermario \
+  --model "your-org/your-model" \
+  --wallet owner \
+  --hotkey default
+```
+
 Deploy one endpoint and commit it for both currently supported competitions:
 
 ```bash
@@ -289,6 +299,7 @@ Current profiles include:
 
 - `deploy/profiles/codenames.json`
 - `deploy/profiles/twentyq.json`
+- `deploy/profiles/supermario.json`
 - `deploy/profiles/all.json`
 
 At the moment these files intentionally use the same container template. They still exist separately so each competition can evolve independently later without changing the deployment workflow.
@@ -313,10 +324,11 @@ Important env placeholders used in these JSON files:
 - `${MINER_HOTKEY}`: hotkey SS58 address from the wallet
 - `${REASONING}`: value passed via `--reasoning`
 
-#### Difference between `codenames.json`, `twentyq.json`, and `all.json`
+#### Difference between `codenames.json`, `twentyq.json`, `supermario.json`, and `all.json`
 
 - `codenames.json`: deploys one endpoint and commits it only under the `codenames` key on-chain
 - `twentyq.json`: deploys one endpoint and commits it only under the `twentyq` key on-chain
+- `supermario.json`: deploys one endpoint and commits it only under the `supermario` key on-chain
 - `all.json`: deploys one endpoint and commits the same endpoint under both `codenames` and `twentyq`
 
 That means `all.json` is for miners who want one shared model endpoint to serve multiple competitions. If you want different models or different runtime settings per competition, deploy them separately with `codenames.json` and `twentyq.json`.
@@ -328,7 +340,8 @@ The miner keeps the original plain JSON commitment format. After deployment, the
 ```json
 {
   "codenames": "serv-u-xxxxxxxxxxxxxxxx",
-  "twentyq": "serv-u-yyyyyyyyyyyyyyyy"
+  "twentyq": "serv-u-yyyyyyyyyyyyyyyy",
+  "supermario": "serv-u-zzzzzzzzzzzzzzzz"
 }
 ```
 

--- a/deploy/miner.py
+++ b/deploy/miner.py
@@ -14,6 +14,7 @@ import httpx
 from targon.cli.auth import get_stored_key
 from targon.utils.config_parser import load_config
 from game.common.targon import extract_workload_uid, normalize_endpoint_url
+from game.core.codes import normalize_game_code
 
 bt.logging.off()
 
@@ -43,7 +44,7 @@ def _ensure_typing_self() -> None:
 
 
 def _resolve_competition(value: str) -> tuple[str, list[str], Path, str]:
-    normalized = value.strip().lower()
+    normalized = normalize_game_code(value)
     config_path = PROFILES_DIR / f"{normalized}.json"
     if not config_path.exists():
         available = sorted(p.stem for p in PROFILES_DIR.glob("*.json"))

--- a/deploy/profiles/supermario.json
+++ b/deploy/profiles/supermario.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.0",
+  "app_name": "brainplay",
+  "containers": [
+    {
+      "name": "${NAME}",
+      "resource": "h100-small",
+      "image": "shiftlayer/brainplay-llm:latest",
+      "port": 80,
+      "env": {
+        "MODEL": "${MODEL}",
+        "SGLANG_EXTRA_ARGS": "${SGLANG_EXTRA_ARGS}",
+        "MINER_HOTKEY": "${MINER_HOTKEY}",
+        "REASONING": "${REASONING}"
+      },
+      "replicas": {
+        "min": 1,
+        "max": 1,
+        "target_concurrency": 30
+      }
+    }
+  ]
+}

--- a/design/mario/mario.arch.md
+++ b/design/mario/mario.arch.md
@@ -1,0 +1,75 @@
+# SuperMario Subnet Architecture
+
+## Design Goal
+Implement `supermario` as the first vision competition on Brainplay by reusing the shared validator lifecycle, backend room flow, and generic score persistence introduced for multi-game support.
+
+Canonical names:
+- game code: `supermario`
+- competition code: `supermario`
+- temporary miner/deploy alias: `mario`
+
+Weight metadata:
+- `weight_group=vision`
+- `publish_mechid=1`
+
+## Reused Core Architecture
+
+SuperMario keeps these shared paths:
+- validator entry and lifecycle in `neurons/validator.py` and `game/base/validator.py`
+- plugin registry in `game/core/registry.py`
+- signed backend API client in `game/providers/backend_client.py`
+- endpoint commitment resolution in `game/core/endpoint_resolver.py`
+- generic session/attempt persistence in `game/storage/store.py`
+- shared weight publication through `game/storage/weight_state.py`
+
+## SuperMario-Specific Modules
+
+The game-specific validator implementation lives in:
+- `game/plugins/supermario/plugin.py`
+- `game/plugins/supermario/validator_runner.py`
+- `game/plugins/supermario/protocol.py`
+- `game/plugins/supermario/models.py`
+- `game/plugins/supermario/backend_mapper.py`
+- `game/plugins/supermario/scoring.py`
+
+## Validator Round Model
+
+Each validator round creates one shared backend room and one isolated Mario benchmark run per selected miner.
+
+Round flow:
+1. sync historical scores from backend
+2. resolve committed miner endpoints for `supermario`
+3. create backend room at `/api/v1/games/supermario/create`
+4. submit `POST /runs` to each selected miner image
+5. poll `GET /runs/{run_id}` and `GET /runs/{run_id}/steps`
+6. patch backend room state incrementally with step/frame data
+7. normalize final scores across miners
+8. finalize backend room and publish weights through the shared `vision` group path
+
+## Miner Image Contract
+
+The Brainplay image exposes:
+- `POST /runs`
+- `GET /runs/{run_id}`
+- `GET /runs/{run_id}/steps?cursor=<n>`
+- `GET /runs/{run_id}/video`
+
+The validator uploads normalized step data to backend. Backend remains the canonical history store for:
+- room snapshots
+- per-step records
+- frame metadata
+- persisted JPG content
+
+## Scoring
+
+Final ranking is round-relative:
+- rank by `(level_complete, progress_from_start, env_score, steps_used asc, elapsed_s asc)`
+- top miner gets `1.0`
+- remaining successful miners get `progress_from_start / best_progress`
+- failed, invalid, or artifact-less attempts get `0.0`
+
+## Compatibility Notes
+
+- `mario` remains accepted as an alias in deploy/profile selection, but chain commitments and runtime code standardize on `supermario`
+- `codenames` and `twentyq` publish through the shared `llm` group
+- `supermario` publishes through the shared `vision` group

--- a/design/mario/mario.backend.md
+++ b/design/mario/mario.backend.md
@@ -1,0 +1,105 @@
+# SuperMario Backend Integration
+
+## Canonical Backend Module
+
+The backend implementation already exists under:
+- `/root/evm/backend/src/App/games_v2/supermario/*`
+
+Base route prefix:
+- `/api/v1/games/supermario`
+
+## Active Contracts Used by the Validator
+
+### Create room
+- `POST /api/v1/games/supermario/create`
+- signed validator headers required
+- whitelist validation required
+
+Request:
+- `validatorKey`
+- `competition=supermario`
+- `participants`
+- `level`
+- `seed`
+- `step_limit`
+
+### Incremental room updates
+- `PATCH /api/v1/games/supermario/:roomId`
+
+Per-participant update payload includes:
+- `hotkey`
+- `is_finished`
+- `finish_reason`
+- `score`
+- `steps_count`
+- `last_frame_id`
+- `last_control`
+- `progress`
+- incremental `steps[]`
+
+Each step carries:
+- `step_index`
+- `control`
+- `captured_at`
+- `reward_delta`
+- `progress`
+- `frame { mime_type, jpg_base64, width, height }`
+
+### Final score sync
+- `PATCH /api/v1/games/supermario/score/:roomId`
+
+Payload:
+- `reason`
+- `participants[{ hotkey, score }]`
+
+### Final video upload
+- `PATCH /api/v1/games/supermario/video/:roomId`
+
+Payload:
+- `participant_hotkey`
+- `run_id`
+- `mime_type=video/mp4`
+- `video_base64`
+
+## Storage Behavior
+
+Backend persistence uses:
+- Redis active room: `supermario:room:{roomId}`
+- Redis save queue: `supermario:saveQueue:{roomId}`
+- Mongo room history: `supermario_room_history`
+- Mongo step history: `supermario_step_history`
+- Mongo frame metadata: `supermario_frame_assets`
+
+Frame bytes are stored by backend according to backend config:
+- `SUPERMARIO_FRAME_STORAGE_MODE=memory` for live step frames
+- `SUPERMARIO_FRAME_STORAGE_MODE=filesystem` for filesystem-backed frame persistence
+- `SUPERMARIO_FRAME_STORAGE_MODE=db` only as a compatibility mode
+
+Final videos are stored by backend according to backend config:
+- `SUPERMARIO_VIDEO_STORAGE_MODE=r2`
+- `SUPERMARIO_VIDEO_STORAGE_MODE=filesystem`
+- `SUPERMARIO_VIDEO_STORAGE_MODE=db` only as a compatibility mode
+
+## Security Requirements
+
+SuperMario uses the same middleware posture as codenames:
+- `CustomRateLimitMiddleware`
+- `ValidateGameRequestMiddlewares.validateGameRequest`
+- `ValidatorMiddleware.validateWhitelistHotkey`
+
+Applied to:
+- `/create`
+- `/:roomId`
+- `/score/:roomId`
+- `/video/:roomId`
+- `/sync`
+
+## Validator Expectations
+
+The subnet validator assumes:
+- create returns `{ ok: true, data: { id } }`
+- update returns `{ ok: true }`
+- score returns `{ ok: true }`
+- sync exposes finalized sessions for score refresh
+
+If frame storage is on filesystem, backend still remains the source of truth because it owns the frame metadata table.

--- a/design/mario/mario.tasks.md
+++ b/design/mario/mario.tasks.md
@@ -1,0 +1,40 @@
+# SuperMario Integration Tasks
+
+## Subnet
+
+- add canonical `supermario` support to `game/core/codes.py`
+- accept `mario` as an alias only
+- register `game/plugins/supermario/*`
+- move non-codenames endpoint resolution onto generic competition-code lookup
+- publish weights through shared `weight_group` and `publish_mechid` state
+- add `deploy/profiles/supermario.json`
+- make `deploy/miner.py --competition mario` normalize to `supermario`
+
+## Backend
+
+- keep `src/App/games_v2/supermario/*` as the canonical backend module
+- enable codenames-style auth and rate-limit middleware on SuperMario write/sync routes
+- keep room, step, and frame persistence contracts unchanged
+- update `docs/supermario.md` to reflect current implementation
+
+## Miner Image
+
+- keep existing run lifecycle endpoints
+- add `GET /runs/{run_id}/steps`
+- export normalized step payloads with backend-compatible JPG frame data
+- preserve Epistula auth on all Mario endpoints
+
+## Tests
+
+- subnet unit tests for canonical codes and SuperMario scoring
+- backend route/service/controller tests
+- image runtime tests for step export and authenticated route exposure
+
+## Rollout Defaults
+
+- canonical competition key on-chain: `supermario`
+- temporary CLI/profile alias: `mario`
+- default level: `1-1`
+- default step limit: `3000`
+- default weight lane: `vision`
+- default publish mechid: `1`

--- a/design/mario/mario.workflow.md
+++ b/design/mario/mario.workflow.md
@@ -1,0 +1,60 @@
+# SuperMario Validator Workflow
+
+## Round Setup
+
+Inputs:
+- competition code `supermario`
+- miner commitments under `supermario`
+- deployed Brainplay image with Mario run API
+
+Validator actions:
+1. refresh score sync state from backend
+2. read committed `supermario` endpoints from chain
+3. probe `/meta` and keep only responsive miners
+4. create backend room with selected hotkeys
+
+## Per-Miner Attempt Workflow
+
+For each selected miner:
+1. submit `POST /runs`
+2. store returned `run_id`
+3. poll `GET /runs/{run_id}`
+4. poll `GET /runs/{run_id}/steps?cursor=<n>`
+5. forward new steps to backend room patch endpoint
+6. continue until status becomes `succeeded` or `failed`
+7. finalize participant status and include score after round normalization
+
+## Step Export Workflow
+
+The miner image exports normalized steps in cursor order.
+
+Each step is converted by the validator into backend-compatible data and uploaded immediately. This keeps:
+- live room state visible in Redis/socket views
+- step history persisted incrementally
+- frame assets persisted by backend rather than left only on miner disk
+
+## Finalization Workflow
+
+Once all participants finish:
+1. compute normalized round scores
+2. patch backend room with final participant states
+3. call backend score endpoint
+4. persist generic session/attempt rows locally
+5. publish the resulting weight snapshot through the shared `vision` aggregation path
+
+## Failure Handling
+
+If no miners are available:
+- skip the round cleanly
+
+If room creation fails:
+- skip the round and keep no partial session
+
+If a miner run fails:
+- mark that participant with `finish_reason=error`
+- score `0.0`
+- continue the round for other miners
+
+If the shared `vision` group cannot publish:
+- keep the latest successful aggregate if one exists
+- otherwise publish burn weights for `mechid=1`

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 # Define the version of the module.
-__version__ = "2.3.3"
+__version__ = "2.4.0"
 version_split = __version__.split(".")
 __spec_version__ = (
     (1000 * int(version_split[0]))

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -25,6 +25,20 @@ __spec_version__ = (
     + (1 * int(version_split[2]))
 )
 __image_hash__ = "4b9ba675ef3c8ca8b8e41dfe7636b5c72c507711befe76562d18326572efcfef"
+__mario_image_hash__ = (
+    "4b9ba675ef3c8ca8b8e41dfe7636b5c72c507711befe76562d18326572efcfef"
+)
+
+_IMAGE_HASH_BY_COMPETITION = {
+    "mario": __mario_image_hash__,
+    "supermario": __mario_image_hash__,
+}
+
+
+def get_image_hash_for_competition(competition: str | None) -> str:
+    normalized = (competition or "").strip().lower()
+    return _IMAGE_HASH_BY_COMPETITION.get(normalized, __image_hash__)
+
 
 # Import all submodules.
 from . import protocol

--- a/game/base/neuron.py
+++ b/game/base/neuron.py
@@ -24,6 +24,7 @@ from abc import ABC, abstractmethod
 
 # Sync calls set weights and also resyncs the metagraph.
 from game.config import check_config, add_args, config
+from game.core.codes import get_game_code_info, normalize_game_code
 from game.plugins.codenames.game_types import Competition
 from game.common.misc import ttl_get_block
 from game import __spec_version__ as spec_version
@@ -84,8 +85,9 @@ class BaseNeuron(ABC):
         if self.config.competition == "main":
             self.mechid = 0
         else:
-            competition = Competition(self.config.competition)
-            self.mechid = competition.mechid
+            self.config.competition = normalize_game_code(self.config.competition)
+            competition_info = get_game_code_info(self.config.competition)
+            self.mechid = competition_info.publish_mechid
         self.metagraph: bt.Metagraph = self.subtensor.metagraph(
             self.config.netuid, mechid=self.mechid
         )

--- a/game/base/validator.py
+++ b/game/base/validator.py
@@ -39,12 +39,19 @@ from game.base.utils.weight_utils import (
     process_weights_for_netuid,
     convert_weights_and_uids_for_emit,
 )  # TODO: Replace when bittensor switches to numpy
+from game.core.codes import (
+    get_game_code_info,
+    list_supported_game_codes,
+    list_supported_game_codes_for_weight_group,
+    normalize_game_code,
+)
 from game.core.registry import get_registry
 from game.config import add_validator_args
 from game.config.defaults import DEFAULT_SCORING_INTERVAL
 from game.storage.aggregation import parse_interval_to_seconds
 from game.storage.legacy_codenames_store import ScoreStore
 from game.storage.store import GenericStore
+from game.storage.weight_state import WeightStateStore
 from game.plugins.codenames.game_types import Competition, Game
 from dotenv import load_dotenv
 
@@ -91,7 +98,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
     @staticmethod
     def _competition_codes_for_main() -> list[str]:
-        return [competition.value for competition in Competition]
+        return list(list_supported_game_codes())
 
     @staticmethod
     def _base_validator_argv(argv: list[str]) -> list[str]:
@@ -168,6 +175,10 @@ class BaseValidatorNeuron(BaseNeuron):
             from game.plugins.twentyq import get_twentyq_plugin
 
             registry.register(get_twentyq_plugin())
+        if registry.maybe_get_by_game_code("supermario") is None:
+            from game.plugins.supermario import get_supermario_plugin
+
+            registry.register(get_supermario_plugin())
         return registry
 
     def _resolve_game_plugin_from_config(self) -> Optional[object]:
@@ -305,6 +316,8 @@ class BaseValidatorNeuron(BaseNeuron):
         self.generic_store = GenericStore(scores_db_path)
         self.generic_store.init()
         self.score_store.generic_store = self.generic_store
+        self.weight_state = WeightStateStore("/tmp/brainplay_weight_state.db")
+        self.weight_state.init()
         scoring_interval_text = DEFAULT_SCORING_INTERVAL
         if hasattr(self.config, "scoring") and getattr(
             self.config.scoring, "interval", None
@@ -333,16 +346,19 @@ class BaseValidatorNeuron(BaseNeuron):
         """
 
         # Init competition and game codes
+        self.config.competition = normalize_game_code(self.config.competition)
         competition = Competition(self.config.competition)
+        competition_info = get_game_code_info(self.config.competition)
         configured_game_code = getattr(self.config.game, "code", None)
+        configured_game_code = normalize_game_code(configured_game_code)
         if competition != Competition.CODENAMES and (
             not configured_game_code or configured_game_code == "codenames"
         ):
-            configured_game_code = competition.value
-            self.config.game.code = configured_game_code
+            configured_game_code = competition_info.game_code
+        self.config.game.code = configured_game_code
         game = Game(configured_game_code)
         self.competition = competition
-        self.mechid = competition.mechid
+        self.mechid = competition_info.publish_mechid
         self.game = game
         self.game_plugin = self._resolve_game_plugin_from_config()
         if self.game_plugin is not None:
@@ -576,6 +592,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         competition = self.competition
         comp_value = competition.value
+        competition_info = get_game_code_info(comp_value)
         validator_hotkey = self.wallet.hotkey.ss58_address
         use_generic_scores = (
             comp_value != "codenames"
@@ -596,7 +613,15 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 f"Latest synced score is older than 1 hour ({age_seconds:.0f}s). Switching to burn code."
             )
-            self._burn_weights()
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="stale",
+                scores_summary={"reason": "stale_scores", "age_seconds": age_seconds},
+            )
             return
 
         weights = np.zeros(self.metagraph.n, dtype=np.float32)
@@ -705,7 +730,15 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 f"Not enough games for competition {comp_value}; skipping its allocation. ({comp_games} < 30)"
             )
-            self._burn_weights(competition.mechid)
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="insufficient_games",
+                scores_summary={"games": comp_games},
+            )
             return
 
         avg_scores_after_record_limit = {
@@ -717,6 +750,15 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 f"No scores for competition {comp_value}; skipping its allocation."
             )
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="no_scores",
+                scores_summary={"games": comp_games},
+            )
             return
 
         top_score = max(avg_scores_after_record_limit.values())
@@ -724,7 +766,15 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 f"Top score for competition {comp_value} is non-positive; skipping."
             )
-            self._burn_weights(competition.mechid)
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="non_positive_top_score",
+                scores_summary={"top_score": top_score},
+            )
             return
 
         top_hotkeys = [
@@ -744,14 +794,30 @@ class BaseValidatorNeuron(BaseNeuron):
             bt.logging.warning(
                 f"No top hotkeys for competition {comp_value} present in metagraph; skipping."
             )
-            self._burn_weights(competition.mechid)
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="winner_missing",
+                scores_summary={"top_hotkeys": top_hotkeys},
+            )
             return
 
         if len(winner_uids) > 1:
             bt.logging.info(
                 f"Competition {comp_value} has multiple winners: {winner_uids} with score {top_score}; skipping"
             )
-            self._burn_weights(competition.mechid)
+            self._store_and_publish_weight_snapshot(
+                competition_code=comp_value,
+                competition_info=competition_info,
+                since_ts=since_ts,
+                end_ts=end_ts,
+                raw_weights=self._burn_vector(),
+                status="tied_winner",
+                scores_summary={"winner_uids": winner_uids, "top_score": top_score},
+            )
             return
 
         # Set minimum weight for scored miners
@@ -783,10 +849,131 @@ class BaseValidatorNeuron(BaseNeuron):
             norm = np.ones_like(norm)
         raw_weights = weights / norm
 
-        self._set_weights(competition.mechid, raw_weights)
+        self._store_and_publish_weight_snapshot(
+            competition_code=comp_value,
+            competition_info=competition_info,
+            since_ts=since_ts,
+            end_ts=end_ts,
+            raw_weights=raw_weights,
+            status="ready",
+            scores_summary={
+                "top_score": top_score,
+                "winner_hotkey": winner_hotkey,
+            },
+        )
         time.sleep(12)  # Sleep to avoid nonce issues
 
         self.resync_metagraph()
+
+    def _burn_vector(self) -> np.ndarray:
+        burn_weights = np.zeros(self.metagraph.n, dtype=np.float32)
+        if self.metagraph.n > 0:
+            burn_weights[0] = 1.0
+        return burn_weights
+
+    def _store_and_publish_weight_snapshot(
+        self,
+        *,
+        competition_code: str,
+        competition_info,
+        since_ts: float,
+        end_ts: float,
+        raw_weights: np.ndarray,
+        status: str,
+        scores_summary: dict,
+    ) -> None:
+        validator_hotkey = self.wallet.hotkey.ss58_address
+        self.weight_state.upsert_snapshot(
+            validator_hotkey=validator_hotkey,
+            competition_code=competition_code,
+            weight_group=competition_info.weight_group,
+            publish_mechid=competition_info.publish_mechid,
+            window_since_ts=int(since_ts),
+            window_end_ts=int(end_ts),
+            weights=raw_weights,
+            scores_summary=scores_summary,
+            status=status,
+        )
+        self._publish_weight_group(
+            validator_hotkey=validator_hotkey,
+            weight_group=competition_info.weight_group,
+            publish_mechid=competition_info.publish_mechid,
+        )
+
+    def _publish_weight_group(
+        self,
+        *,
+        validator_hotkey: str,
+        weight_group: str,
+        publish_mechid: int,
+    ) -> None:
+        required_codes = list_supported_game_codes_for_weight_group(weight_group)
+        snapshots = self.weight_state.get_fresh_snapshots(
+            validator_hotkey=validator_hotkey,
+            weight_group=weight_group,
+            freshness_ttl_sec=3600,
+        )
+        ready_snapshots = {
+            code: snapshot
+            for code, snapshot in snapshots.items()
+            if snapshot.get("status") == "ready"
+        }
+        missing_codes = [code for code in required_codes if code not in ready_snapshots]
+        if missing_codes:
+            previous = self.weight_state.get_publication(
+                validator_hotkey=validator_hotkey, weight_group=weight_group
+            )
+            if previous is not None:
+                bt.logging.info(
+                    f"[WEIGHTS] Missing fresh snapshots for group={weight_group}: "
+                    f"{missing_codes}; keeping last publication."
+                )
+                return
+            bt.logging.warning(
+                f"[WEIGHTS] Missing fresh snapshots for group={weight_group}: "
+                f"{missing_codes}; publishing burn weights."
+            )
+            final_weights = self._burn_vector()
+        else:
+            ratios = self._weight_group_ratios(weight_group, ready_snapshots)
+            final_weights = np.zeros(self.metagraph.n, dtype=np.float32)
+            for code, ratio in ratios.items():
+                snapshot_weights = np.asarray(
+                    ready_snapshots[code]["weights"], dtype=np.float32
+                )
+                if snapshot_weights.shape[0] != self.metagraph.n:
+                    bt.logging.warning(
+                        f"[WEIGHTS] Snapshot size mismatch for {code}; publishing burn."
+                    )
+                    final_weights = self._burn_vector()
+                    break
+                final_weights = final_weights + (snapshot_weights * float(ratio))
+            norm = np.linalg.norm(final_weights, ord=1, axis=0, keepdims=True)
+            if np.any(norm == 0) or np.isnan(norm).any():
+                final_weights = self._burn_vector()
+            else:
+                final_weights = final_weights / norm
+
+        self._set_weights(publish_mechid, final_weights)
+        self.weight_state.upsert_publication(
+            validator_hotkey=validator_hotkey,
+            weight_group=weight_group,
+            publish_mechid=publish_mechid,
+            weights=final_weights,
+            source_competitions=list(required_codes),
+        )
+
+    @staticmethod
+    def _weight_group_ratios(
+        weight_group: str, snapshots: dict[str, dict]
+    ) -> dict[str, float]:
+        if weight_group == "llm" and {"codenames", "twentyq"}.issubset(
+            snapshots.keys()
+        ):
+            return {"codenames": 0.5, "twentyq": 0.5}
+        count = max(1, len(snapshots))
+        ratio = 1.0 / float(count)
+        return {code: ratio for code in snapshots}
 
     def _log_competition_scores(
         self,
@@ -909,9 +1096,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
     def _burn_weights(self, mechid: int = None) -> None:
         """Sets weights to burn code (all weight to UID 0)."""
-        burn_weights = np.zeros(self.metagraph.n, dtype=np.float32)
-        if self.metagraph.n > 0:
-            burn_weights[0] = 1.0
+        burn_weights = self._burn_vector()
         if mechid is None:
             self._set_weights(0, burn_weights)
             self._set_weights(1, burn_weights)

--- a/game/core/codes.py
+++ b/game/core/codes.py
@@ -17,6 +17,8 @@ class GameCodeInfo:
     competition_code: str
     mechid: int
     display_name: str
+    weight_group: str = "llm"
+    publish_mechid: int = 0
     default_interval: str = "1 minutes"
 
 
@@ -27,19 +29,34 @@ _SUPPORTED_GAMES: Dict[str, GameCodeInfo] = {
         competition_code="codenames",
         mechid=0,
         display_name="Codenames",
+        weight_group="llm",
+        publish_mechid=0,
     ),
     "twentyq": GameCodeInfo(
         game_code="twentyq",
         competition_code="twentyq",
-        mechid=1,
+        mechid=0,
         display_name="20 Questions",
+        weight_group="llm",
+        publish_mechid=0,
     ),
+    "supermario": GameCodeInfo(
+        game_code="supermario",
+        competition_code="supermario",
+        mechid=1,
+        display_name="SuperMario",
+        weight_group="vision",
+        publish_mechid=1,
+    ),
+}
+
+_ALIASES: Dict[str, str] = {
+    "mario": "supermario",
 }
 
 
 # Reserved/planned codes (no mechid guarantees yet).
 _RESERVED_GAME_CODES: Tuple[str, ...] = (
-    "mario",
     "2048",
     "pacman",
     "chess",
@@ -49,7 +66,8 @@ _RESERVED_GAME_CODES: Tuple[str, ...] = (
 
 def normalize_game_code(code: str) -> str:
     """Normalize a user-provided game/competition code."""
-    return (code or "").strip().lower()
+    normalized = (code or "").strip().lower()
+    return _ALIASES.get(normalized, normalized)
 
 
 def get_game_code_info(code: str) -> GameCodeInfo:
@@ -64,6 +82,19 @@ def get_game_code_info(code: str) -> GameCodeInfo:
 def list_supported_game_codes() -> Tuple[str, ...]:
     """List runtime-supported game codes in stable order."""
     return tuple(_SUPPORTED_GAMES.keys())
+
+
+def list_supported_game_infos() -> Tuple[GameCodeInfo, ...]:
+    return tuple(_SUPPORTED_GAMES.values())
+
+
+def list_supported_game_codes_for_weight_group(weight_group: str) -> Tuple[str, ...]:
+    normalized = normalize_game_code(weight_group)
+    return tuple(
+        info.game_code
+        for info in _SUPPORTED_GAMES.values()
+        if normalize_game_code(info.weight_group) == normalized
+    )
 
 
 def list_reserved_game_codes() -> Tuple[str, ...]:

--- a/game/core/interfaces.py
+++ b/game/core/interfaces.py
@@ -73,6 +73,8 @@ class GamePlugin(Protocol):
     game_code: str
     competition_code: str
     mechid: int
+    weight_group: str
+    publish_mechid: int
     display_name: str
     protocol_version: str
 

--- a/game/core/registry.py
+++ b/game/core/registry.py
@@ -26,7 +26,7 @@ class GameRegistry:
     def __init__(self) -> None:
         self._by_game_code: Dict[str, GamePlugin] = {}
         self._by_competition_code: Dict[str, GamePlugin] = {}
-        self._by_mechid: Dict[int, GamePlugin] = {}
+        self._by_mechid: Dict[int, List[GamePlugin]] = {}
         self._lock = threading.RLock()
 
     def clear(self) -> None:
@@ -58,13 +58,11 @@ class GameRegistry:
                 plugin,
                 f"competition_code={competition_code}",
             )
-            self._check_conflict(
-                self._by_mechid.get(mechid), plugin, f"mechid={mechid}"
-            )
-
             self._by_game_code[game_code] = plugin
             self._by_competition_code[competition_code] = plugin
-            self._by_mechid[mechid] = plugin
+            matches = self._by_mechid.setdefault(mechid, [])
+            if plugin not in matches:
+                matches.append(plugin)
 
         return plugin
 
@@ -93,9 +91,15 @@ class GameRegistry:
     def get_by_mechid(self, mechid: int) -> GamePlugin:
         with self._lock:
             try:
-                return self._by_mechid[int(mechid)]
+                matches = self._by_mechid[int(mechid)]
             except KeyError as exc:
                 raise KeyError(f"Unknown mechid: {mechid!r}") from exc
+            if len(matches) != 1:
+                raise KeyError(
+                    f"mechid={mechid!r} maps to multiple plugins; "
+                    "resolve by game_code or competition_code instead"
+                )
+            return matches[0]
 
     def maybe_get_by_game_code(self, game_code: str) -> Optional[GamePlugin]:
         key = _norm(game_code)

--- a/game/plugins/codenames/game_types.py
+++ b/game/plugins/codenames/game_types.py
@@ -18,17 +18,21 @@ word_files = [
 class Game(Enum):
     CODENAMES = "codenames"
     TWENTYQ = "twentyq"
+    SUPERMARIO = "supermario"
 
 
 class Competition(Enum):
     CODENAMES = "codenames"
     TWENTYQ = "twentyq"
+    SUPERMARIO = "supermario"
 
     @property
     def mechid(self) -> int:
         if self == Competition.CODENAMES:
             return 0
         if self == Competition.TWENTYQ:
+            return 0
+        if self == Competition.SUPERMARIO:
             return 1
         return None
 

--- a/game/plugins/codenames/plugin.py
+++ b/game/plugins/codenames/plugin.py
@@ -12,6 +12,8 @@ class CodenamesPlugin:
         self.game_code = info.game_code
         self.competition_code = info.competition_code
         self.mechid = info.mechid
+        self.weight_group = info.weight_group
+        self.publish_mechid = info.publish_mechid
         self.display_name = info.display_name
         self.protocol_version = "legacy-codenames@1"
 

--- a/game/plugins/supermario/__init__.py
+++ b/game/plugins/supermario/__init__.py
@@ -1,0 +1,5 @@
+"""SuperMario plugin package."""
+
+from .plugin import SuperMarioPlugin, get_supermario_plugin
+
+__all__ = ["SuperMarioPlugin", "get_supermario_plugin"]

--- a/game/plugins/supermario/backend_mapper.py
+++ b/game/plugins/supermario/backend_mapper.py
@@ -21,6 +21,7 @@ def _participant_to_payload(
         "is_finished": participant.is_finished,
         "finish_reason": participant.finish_reason,
         "score": float(participant.score),
+        "env_score": float(participant.env_score),
         "steps_count": int(participant.steps_count),
         "last_frame_id": participant.last_frame_id,
         "last_control": participant.last_control,

--- a/game/plugins/supermario/backend_mapper.py
+++ b/game/plugins/supermario/backend_mapper.py
@@ -1,0 +1,75 @@
+"""Payload mappers for SuperMario backend contracts."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
+from game.plugins.supermario.models import (
+    SuperMarioAttemptState,
+    SuperMarioRoomState,
+    SuperMarioStepPayload,
+)
+
+
+def _participant_to_payload(
+    participant: SuperMarioAttemptState,
+    *,
+    steps: Iterable[SuperMarioStepPayload] | None = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "hotkey": participant.hotkey,
+        "is_finished": participant.is_finished,
+        "finish_reason": participant.finish_reason,
+        "score": float(participant.score),
+        "steps_count": int(participant.steps_count),
+        "last_frame_id": participant.last_frame_id,
+        "last_control": participant.last_control,
+        "progress": participant.progress.model_dump(),
+    }
+    if steps:
+        payload["steps"] = [step.model_dump() for step in steps]
+    return payload
+
+
+def make_create_payload(room: SuperMarioRoomState) -> Dict[str, Any]:
+    return {
+        "validatorKey": room.validator_key,
+        "competition": room.competition,
+        "participants": [participant.hotkey for participant in room.participants],
+        "level": room.level,
+        "seed": room.seed,
+        "step_limit": int(room.step_limit),
+    }
+
+
+def make_update_payload(
+    room: SuperMarioRoomState,
+    participants: Iterable[SuperMarioAttemptState] | None = None,
+    *,
+    steps_by_hotkey: dict[str, list[SuperMarioStepPayload]] | None = None,
+) -> Dict[str, Any]:
+    changed = (
+        list(participants) if participants is not None else list(room.participants)
+    )
+    return {
+        "validatorKey": room.validator_key,
+        "competition": room.competition,
+        "status": room.status,
+        "level": room.level,
+        "step_count": int(room.step_count),
+        "participants": [
+            _participant_to_payload(
+                participant,
+                steps=(steps_by_hotkey or {}).get(participant.hotkey),
+            )
+            for participant in changed
+        ],
+    }
+
+
+def make_score_payload(room: SuperMarioRoomState, *, reason: str) -> Dict[str, Any]:
+    participants = [
+        {"hotkey": participant.hotkey, "score": float(participant.score)}
+        for participant in room.participants
+    ]
+    return {"reason": reason, "scores": participants, "participants": participants}

--- a/game/plugins/supermario/models.py
+++ b/game/plugins/supermario/models.py
@@ -41,6 +41,7 @@ class SuperMarioAttemptState(BaseModel):
     score: float = 0.0
     steps_count: int = 0
     last_frame_id: str | None = None
+    last_video_id: str | None = None
     last_control: str | None = None
     progress: SuperMarioProgress = Field(default_factory=SuperMarioProgress)
     level_complete: bool = False

--- a/game/plugins/supermario/models.py
+++ b/game/plugins/supermario/models.py
@@ -1,0 +1,65 @@
+"""SuperMario validator runtime state."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SuperMarioProgress(BaseModel):
+    x: int = 0
+    y: int = 0
+    coins: int = 0
+    lives: int = 0
+    world: int = 0
+    stage: int = 0
+    done: bool = False
+
+
+class SuperMarioFramePayload(BaseModel):
+    mime_type: str = "image/jpeg"
+    jpg_base64: str
+    width: int
+    height: int
+
+
+class SuperMarioStepPayload(BaseModel):
+    step_index: int
+    control: str
+    captured_at: int
+    reward_delta: float = 0.0
+    progress: SuperMarioProgress = Field(default_factory=SuperMarioProgress)
+    frame: SuperMarioFramePayload
+
+
+class SuperMarioAttemptState(BaseModel):
+    uid: int
+    hotkey: str
+    endpoint: str
+    run_id: str | None = None
+    is_finished: bool = False
+    finish_reason: str | None = None
+    score: float = 0.0
+    steps_count: int = 0
+    last_frame_id: str | None = None
+    last_control: str | None = None
+    progress: SuperMarioProgress = Field(default_factory=SuperMarioProgress)
+    level_complete: bool = False
+    progress_from_start: float = 0.0
+    env_score: float = 0.0
+    elapsed_s: float = 0.0
+    step_cursor: int = 0
+    had_artifacts: bool = False
+
+
+class SuperMarioRoomState(BaseModel):
+    room_id: str
+    validator_key: str
+    competition: str = "supermario"
+    status: str = "running"
+    level: str = "1-1"
+    seed: str | None = None
+    step_limit: int = 3000
+    step_count: int = 0
+    participants: list[SuperMarioAttemptState] = Field(default_factory=list)
+    started_at: int
+    ended_at: int | None = None

--- a/game/plugins/supermario/plugin.py
+++ b/game/plugins/supermario/plugin.py
@@ -1,48 +1,45 @@
-"""TwentyQ game plugin metadata and factories."""
+"""SuperMario game plugin metadata and factories."""
 
 from __future__ import annotations
 
 from game.core.codes import get_game_code_info
-from game.plugins.twentyq.validator_runner import TwentyQValidatorRunner
+from game.plugins.supermario.validator_runner import SuperMarioValidatorRunner
 
 
-class TwentyQPlugin:
+class SuperMarioPlugin:
     def __init__(self) -> None:
-        info = get_game_code_info("twentyq")
+        info = get_game_code_info("supermario")
         self.game_code = info.game_code
         self.competition_code = info.competition_code
         self.mechid = info.mechid
         self.weight_group = info.weight_group
         self.publish_mechid = info.publish_mechid
         self.display_name = info.display_name
-        self.protocol_version = "brainplay.twentyq@1"
+        self.protocol_version = "brainplay.supermario@1"
 
     def validate_config(self, config) -> None:
         game_code = getattr(getattr(config, "game", None), "code", None)
         competition_code = getattr(config, "competition", None)
-        if game_code and str(game_code).lower() not in {"twentyq"}:
+        allowed = {"supermario", "mario", "main"}
+        if game_code and str(game_code).lower() not in {"supermario", "mario"}:
             raise ValueError(
-                f"TwentyQPlugin received incompatible game.code={game_code!r}"
+                f"SuperMarioPlugin received incompatible game.code={game_code!r}"
             )
-        if competition_code and str(competition_code).lower() not in {
-            "twentyq",
-            "main",
-        }:
+        if competition_code and str(competition_code).lower() not in allowed:
             raise ValueError(
-                "TwentyQPlugin received incompatible "
+                "SuperMarioPlugin received incompatible "
                 f"competition={competition_code!r}"
             )
 
     def create_validator_runner(self, ctx):
-        return TwentyQValidatorRunner(ctx)
+        return SuperMarioValidatorRunner(ctx)
 
     def create_miner_handler(self, ctx):
-        # Miner-side plugin routing is not implemented yet.
         return None
 
 
-_TWENTYQ_PLUGIN = TwentyQPlugin()
+_SUPERMARIO_PLUGIN = SuperMarioPlugin()
 
 
-def get_twentyq_plugin() -> TwentyQPlugin:
-    return _TWENTYQ_PLUGIN
+def get_supermario_plugin() -> SuperMarioPlugin:
+    return _SUPERMARIO_PLUGIN

--- a/game/plugins/supermario/protocol.py
+++ b/game/plugins/supermario/protocol.py
@@ -1,0 +1,56 @@
+"""SuperMario runtime protocol models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SuperMarioRunRequest(BaseModel):
+    num_runs: int = 1
+    max_steps_per_episode: int = 3000
+    parallel_runs: int = 1
+    token_limit: int = 2048
+    request_timeout_s: int = 300
+    request_max_retries: int = 3
+
+
+class SuperMarioRunCurrent(BaseModel):
+    episode: int = 0
+    step: int = 0
+    score: float = 0.0
+    progress_from_start: float = 0.0
+    elapsed_s: float = 0.0
+
+
+class SuperMarioRunEpisodeResult(BaseModel):
+    run_id: str | int | None = None
+    score: float = 0.0
+    progress_from_start: float = 0.0
+    elapsed_s: float = 0.0
+    finish_reason: str | None = None
+    steps: int = 0
+
+
+class SuperMarioRunResult(BaseModel):
+    summary: dict[str, Any] = Field(default_factory=dict)
+    episodes: list[SuperMarioRunEpisodeResult] = Field(default_factory=list)
+    video_url: str | None = None
+    video_path: str | None = None
+
+
+class SuperMarioRunStatus(BaseModel):
+    run_id: str
+    state: str
+    submitted_at: float | None = None
+    started_at: float | None = None
+    finished_at: float | None = None
+    error: str | None = None
+    request: dict[str, Any] = Field(default_factory=dict)
+    current: SuperMarioRunCurrent | None = None
+    result: SuperMarioRunResult | None = None
+    status_url: str | None = None
+    video_url: str | None = None
+    pid: int | None = None
+    returncode: int | None = None

--- a/game/plugins/supermario/scoring.py
+++ b/game/plugins/supermario/scoring.py
@@ -1,0 +1,46 @@
+"""SuperMario scoring helpers."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from game.plugins.supermario.models import SuperMarioAttemptState
+
+
+def compute_supermario_scores(
+    participants: Iterable[SuperMarioAttemptState],
+) -> dict[str, float]:
+    attempts = list(participants)
+    eligible = [
+        participant
+        for participant in attempts
+        if participant.had_artifacts
+        and participant.finish_reason not in {"error", "invalid_response"}
+    ]
+    if not eligible:
+        return {participant.hotkey: 0.0 for participant in attempts}
+
+    ranked = sorted(
+        eligible,
+        key=lambda participant: (
+            0 if participant.level_complete else 1,
+            -float(participant.progress_from_start),
+            -float(participant.env_score),
+            int(participant.steps_count),
+            float(participant.elapsed_s),
+        ),
+    )
+    best_progress = max(float(ranked[0].progress_from_start), 0.0)
+    scores: dict[str, float] = {participant.hotkey: 0.0 for participant in attempts}
+    for index, participant in enumerate(ranked):
+        if index == 0:
+            scores[participant.hotkey] = 1.0
+            continue
+        if best_progress <= 0:
+            scores[participant.hotkey] = 0.0
+            continue
+        score = max(
+            0.0, min(1.0, float(participant.progress_from_start) / best_progress)
+        )
+        scores[participant.hotkey] = score
+    return scores

--- a/game/plugins/supermario/validator_runner.py
+++ b/game/plugins/supermario/validator_runner.py
@@ -1,0 +1,422 @@
+"""SuperMario validator runner implementation."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+from uuid import uuid4
+
+import bittensor as bt
+import httpx
+
+from game.common.epistula import generate_header
+from game.common.targon import normalize_endpoint_url
+from game.core.endpoint_resolver import read_endpoints_for_competition
+from game.core.interfaces import AttemptResult, SessionResult
+from game.plugins.supermario.backend_mapper import (
+    make_create_payload,
+    make_score_payload,
+    make_update_payload,
+)
+from game.plugins.supermario.models import (
+    SuperMarioAttemptState,
+    SuperMarioFramePayload,
+    SuperMarioProgress,
+    SuperMarioRoomState,
+    SuperMarioStepPayload,
+)
+from game.plugins.supermario.protocol import SuperMarioRunRequest, SuperMarioRunStatus
+from game.plugins.supermario.scoring import compute_supermario_scores
+from game.providers.backend_client import BackendClient
+from game.providers.targon_client import check_endpoints
+
+
+class SuperMarioValidatorRunner:
+    def __init__(self, validator) -> None:
+        self.validator = validator
+        self.backend = BackendClient(
+            base_url=self.validator.backend_base,
+            signer=self.validator.build_signed_headers,
+            timeout_sec=20,
+        )
+        self.level = os.getenv("SUPERMARIO_LEVEL", "1-1")
+        self.step_limit = int(os.getenv("SUPERMARIO_STEP_LIMIT", "3000"))
+        self.poll_interval_sec = float(os.getenv("SUPERMARIO_POLL_INTERVAL_SEC", "5"))
+        self.request_timeout_sec = float(
+            os.getenv("SUPERMARIO_REQUEST_TIMEOUT_SEC", "30")
+        )
+        self.max_create_room_attempts = 3
+
+    async def run_round(self) -> SessionResult:
+        started_at = time.time()
+        try:
+            await asyncio.wait_for(
+                self.validator.score_store.sync_scores_all(), timeout=600
+            )
+        except Exception as err:  # noqa: BLE001
+            bt.logging.warning(
+                f"[SUPERMARIO] Score history sync failed before round: {err}"
+            )
+
+        selected_uids, endpoints = await self._discover_participants()
+        if not selected_uids:
+            ended_at = time.time()
+            return SessionResult(
+                session_id=f"supermario-{uuid4().hex}",
+                game_code="supermario",
+                competition_code="supermario",
+                status="skipped",
+                started_at=started_at,
+                ended_at=ended_at,
+                attempts=(),
+                metadata={"reason": "no_available_miners"},
+            )
+
+        room = SuperMarioRoomState(
+            room_id=f"supermario-{uuid4().hex}",
+            validator_key=self.validator.wallet.hotkey.ss58_address,
+            level=self.level,
+            step_limit=self.step_limit,
+            started_at=int(started_at),
+            participants=[
+                SuperMarioAttemptState(
+                    uid=uid,
+                    hotkey=self.validator.metagraph.hotkeys[uid],
+                    endpoint=endpoints[uid],
+                )
+                for uid in selected_uids
+            ],
+        )
+        created = await self._create_room(room)
+        if not created:
+            ended_at = time.time()
+            return SessionResult(
+                session_id=room.room_id,
+                game_code="supermario",
+                competition_code="supermario",
+                status="skipped",
+                started_at=started_at,
+                ended_at=ended_at,
+                attempts=(),
+                metadata={"reason": "create_room_failed"},
+            )
+
+        await asyncio.gather(
+            *(
+                self._run_attempt(room, participant)
+                for participant in room.participants
+            ),
+            return_exceptions=False,
+        )
+
+        scores = compute_supermario_scores(room.participants)
+        for participant in room.participants:
+            participant.score = float(scores.get(participant.hotkey, 0.0))
+
+        room.status = "completed"
+        room.ended_at = int(time.time())
+        room.step_count = max(
+            (participant.steps_count for participant in room.participants), default=0
+        )
+        await self._update_room(room)
+        await self._sync_scores(room)
+
+        ended_at = time.time()
+        attempts = tuple(
+            AttemptResult(
+                miner_hotkey=participant.hotkey,
+                status=participant.finish_reason or "completed",
+                score=float(participant.score),
+                started_at=started_at,
+                ended_at=ended_at,
+                attempt_id=f"{room.room_id}:{participant.uid}",
+                turns_used=participant.steps_count,
+                metadata={
+                    "uid": participant.uid,
+                    "run_id": participant.run_id,
+                    "level_complete": participant.level_complete,
+                    "progress_from_start": participant.progress_from_start,
+                    "env_score": participant.env_score,
+                    "elapsed_s": participant.elapsed_s,
+                },
+            )
+            for participant in room.participants
+        )
+        return SessionResult(
+            session_id=room.room_id,
+            game_code="supermario",
+            competition_code="supermario",
+            status=room.status,
+            started_at=started_at,
+            ended_at=ended_at,
+            attempts=attempts,
+            metadata={"level": room.level, "participants": len(room.participants)},
+        )
+
+    async def _discover_participants(self) -> tuple[list[int], dict[int, str]]:
+        exclude_set = {
+            int(uid)
+            for uid in self.validator.metagraph.uids
+            if self.validator.metagraph.S[uid]
+            < self.validator.config.neuron.minimum_stake_requirement
+            or self.validator.metagraph.S[uid]
+            > self.validator.config.blacklist.minimum_stake_requirement
+        }
+        uids_to_ping = [
+            int(uid)
+            for uid in self.validator.metagraph.uids
+            if int(uid) not in exclude_set
+        ]
+        endpoints = read_endpoints_for_competition(
+            self.validator,
+            competition_code="supermario",
+            uids=uids_to_ping,
+        )
+        if not endpoints:
+            return [], {}
+        responsive_uids = await check_endpoints(self.validator, endpoints, timeout=30)
+        if not responsive_uids:
+            return [], {}
+        return sorted(responsive_uids), {uid: endpoints[uid] for uid in responsive_uids}
+
+    async def _create_room(self, room: SuperMarioRoomState) -> bool:
+        payload = make_create_payload(room)
+        for _ in range(self.max_create_room_attempts):
+            try:
+                response = await self.backend.create_room("supermario", payload)
+            except Exception as err:  # noqa: BLE001
+                bt.logging.warning(
+                    f"[SUPERMARIO] Failed to create room on backend: {err}"
+                )
+                return False
+            room_id = (
+                (response.get("data") or {}).get("id")
+                if isinstance(response, dict)
+                else None
+            )
+            if room_id:
+                room.room_id = str(room_id)
+                return True
+            await asyncio.sleep(2)
+        return False
+
+    async def _update_room(
+        self,
+        room: SuperMarioRoomState,
+        changed: list[SuperMarioAttemptState] | None = None,
+        *,
+        steps_by_hotkey: dict[str, list[SuperMarioStepPayload]] | None = None,
+    ) -> None:
+        payload = make_update_payload(room, changed, steps_by_hotkey=steps_by_hotkey)
+        try:
+            await self.backend.update_room("supermario", room.room_id, payload)
+        except Exception as err:  # noqa: BLE001
+            bt.logging.debug(
+                f"[SUPERMARIO] Failed to update room {room.room_id}: {err}"
+            )
+
+    async def _sync_scores(self, room: SuperMarioRoomState) -> None:
+        reason = "completed" if room.status == "completed" else "aborted"
+        payload = make_score_payload(room, reason=reason)
+        try:
+            await self.validator.score_store.upload_scores(
+                room_id=room.room_id,
+                competition="supermario",
+                scores=payload["scores"],
+                reason=reason,
+            )
+        except Exception as err:  # noqa: BLE001
+            bt.logging.error(
+                f"[SUPERMARIO] Failed to persist scores for {room.room_id}: {err}"
+            )
+            return
+        try:
+            await self.backend.score_room("supermario", room.room_id, payload)
+        except Exception as err:  # noqa: BLE001
+            bt.logging.debug(
+                f"[SUPERMARIO] score endpoint patch failed for {room.room_id}: {err}"
+            )
+
+    async def _run_attempt(
+        self,
+        room: SuperMarioRoomState,
+        participant: SuperMarioAttemptState,
+    ) -> None:
+        try:
+            run_id = await self._start_run(participant, room)
+        except Exception as err:  # noqa: BLE001
+            participant.is_finished = True
+            participant.finish_reason = "error"
+            bt.logging.warning(
+                f"[SUPERMARIO] Failed to start run for uid={participant.uid}: {err}"
+            )
+            await self._update_room(room, [participant])
+            return
+
+        participant.run_id = run_id
+        try:
+            while True:
+                fetched_steps = await self._fetch_steps(participant)
+                if fetched_steps:
+                    participant.steps_count = max(
+                        participant.steps_count, fetched_steps[-1].step_index
+                    )
+                    participant.last_control = fetched_steps[-1].control
+                    participant.progress = fetched_steps[-1].progress
+                    participant.had_artifacts = True
+                    room.step_count = max(room.step_count, participant.steps_count)
+                    await self._update_room(
+                        room,
+                        [participant],
+                        steps_by_hotkey={participant.hotkey: fetched_steps},
+                    )
+
+                status = await self._fetch_status(participant)
+                if status.current is not None:
+                    participant.progress_from_start = float(
+                        status.current.progress_from_start
+                    )
+                    participant.env_score = float(status.current.score)
+                    participant.elapsed_s = float(status.current.elapsed_s)
+                if status.state in {"succeeded", "failed"}:
+                    break
+                await asyncio.sleep(self.poll_interval_sec)
+
+            trailing_steps = await self._fetch_steps(participant)
+            if trailing_steps:
+                participant.steps_count = max(
+                    participant.steps_count, trailing_steps[-1].step_index
+                )
+                participant.last_control = trailing_steps[-1].control
+                participant.progress = trailing_steps[-1].progress
+                participant.had_artifacts = True
+                room.step_count = max(room.step_count, participant.steps_count)
+                await self._update_room(
+                    room,
+                    [participant],
+                    steps_by_hotkey={participant.hotkey: trailing_steps},
+                )
+
+            await self._finalize_attempt(participant, status)
+        except Exception as err:  # noqa: BLE001
+            participant.is_finished = True
+            participant.finish_reason = "error"
+            bt.logging.warning(
+                f"[SUPERMARIO] Attempt failed for uid={participant.uid} run_id={participant.run_id}: {err}"
+            )
+        await self._update_room(room, [participant])
+
+    async def _finalize_attempt(
+        self,
+        participant: SuperMarioAttemptState,
+        status: SuperMarioRunStatus,
+    ) -> None:
+        participant.is_finished = True
+        if (
+            status.state != "succeeded"
+            or status.result is None
+            or not status.result.episodes
+        ):
+            participant.finish_reason = "error"
+            return
+
+        episode = status.result.episodes[0]
+        participant.had_artifacts = True
+        participant.env_score = float(episode.score)
+        participant.progress_from_start = float(episode.progress_from_start)
+        participant.elapsed_s = float(episode.elapsed_s)
+        participant.steps_count = max(participant.steps_count, int(episode.steps))
+        finish_reason = str(episode.finish_reason or "").lower()
+        participant.level_complete = bool(
+            participant.progress.done
+            or finish_reason in {"terminated", "level_complete"}
+        )
+        participant.finish_reason = self._map_finish_reason(
+            finish_reason, participant.progress.done
+        )
+
+    @staticmethod
+    def _map_finish_reason(raw_reason: str, done: bool) -> str:
+        if done or raw_reason in {"terminated", "level_complete"}:
+            return "level_complete"
+        if raw_reason in {"timeout", "truncated", "max_steps"}:
+            return "timeout"
+        if "death" in raw_reason or "die" in raw_reason:
+            return "death"
+        if "stuck" in raw_reason:
+            return "stuck"
+        if raw_reason == "invalid_response":
+            return "invalid_response"
+        return "error"
+
+    async def _start_run(
+        self, participant: SuperMarioAttemptState, room: SuperMarioRoomState
+    ) -> str:
+        payload = SuperMarioRunRequest(
+            max_steps_per_episode=room.step_limit
+        ).model_dump()
+        response = await self._request_json(
+            participant=participant,
+            method="POST",
+            path="/runs",
+            body=payload,
+        )
+        run_id = str(response.get("run_id") or "")
+        if not run_id:
+            raise RuntimeError(f"run_id missing from response: {response}")
+        return run_id
+
+    async def _fetch_status(
+        self, participant: SuperMarioAttemptState
+    ) -> SuperMarioRunStatus:
+        response = await self._request_json(
+            participant=participant,
+            method="GET",
+            path=f"/runs/{participant.run_id}",
+            body=None,
+        )
+        return SuperMarioRunStatus.model_validate(response)
+
+    async def _fetch_steps(
+        self, participant: SuperMarioAttemptState
+    ) -> list[SuperMarioStepPayload]:
+        response = await self._request_json(
+            participant=participant,
+            method="GET",
+            path=f"/runs/{participant.run_id}/steps?cursor={participant.step_cursor}",
+            body=None,
+        )
+        raw_steps = response.get("steps") or []
+        next_cursor = int(response.get("next_cursor") or participant.step_cursor)
+        steps = [SuperMarioStepPayload.model_validate(step) for step in raw_steps]
+        participant.step_cursor = max(participant.step_cursor, next_cursor)
+        return steps
+
+    async def _request_json(
+        self,
+        *,
+        participant: SuperMarioAttemptState,
+        method: str,
+        path: str,
+        body: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        endpoint = normalize_endpoint_url(participant.endpoint)
+        request_body = body if body is not None else b""
+        headers = generate_header(
+            self.validator.wallet.hotkey,
+            request_body,
+            signed_for=participant.hotkey,
+        )
+        request_kwargs = {"headers": headers}
+        if body is not None:
+            request_kwargs["json"] = body
+        async with httpx.AsyncClient(timeout=self.request_timeout_sec) as client:
+            response = await client.request(
+                method,
+                f"{endpoint}{path}",
+                **request_kwargs,
+            )
+            response.raise_for_status()
+            return response.json()

--- a/game/plugins/supermario/validator_runner.py
+++ b/game/plugins/supermario/validator_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import time
@@ -49,9 +50,13 @@ class SuperMarioValidatorRunner:
             os.getenv("SUPERMARIO_REQUEST_TIMEOUT_SEC", "30")
         )
         self.max_create_room_attempts = 3
+        self.progress_log_interval_sec = float(
+            os.getenv("SUPERMARIO_PROGRESS_LOG_INTERVAL_SEC", "30")
+        )
 
     async def run_round(self) -> SessionResult:
         started_at = time.time()
+        bt.logging.info("[SUPERMARIO] Round start: syncing prior scores.")
         try:
             await asyncio.wait_for(
                 self.validator.score_store.sync_scores_all(), timeout=600
@@ -64,6 +69,9 @@ class SuperMarioValidatorRunner:
         selected_uids, endpoints = await self._discover_participants()
         if not selected_uids:
             ended_at = time.time()
+            bt.logging.info(
+                "[SUPERMARIO] Round skipped: no available miners after endpoint discovery."
+            )
             return SessionResult(
                 session_id=f"supermario-{uuid4().hex}",
                 game_code="supermario",
@@ -90,9 +98,16 @@ class SuperMarioValidatorRunner:
                 for uid in selected_uids
             ],
         )
+        bt.logging.info(
+            f"[SUPERMARIO] Creating backend room for {len(room.participants)} participant(s): "
+            f"uids={selected_uids} level={room.level} step_limit={room.step_limit}"
+        )
         created = await self._create_room(room)
         if not created:
             ended_at = time.time()
+            bt.logging.warning(
+                "[SUPERMARIO] Round skipped: backend room creation failed."
+            )
             return SessionResult(
                 session_id=room.room_id,
                 game_code="supermario",
@@ -104,6 +119,9 @@ class SuperMarioValidatorRunner:
                 metadata={"reason": "create_room_failed"},
             )
 
+        bt.logging.info(
+            f"[SUPERMARIO] Backend room ready: room_id={room.room_id}. Starting miner runs."
+        )
         await asyncio.gather(
             *(
                 self._run_attempt(room, participant)
@@ -112,6 +130,9 @@ class SuperMarioValidatorRunner:
             return_exceptions=False,
         )
 
+        bt.logging.info(
+            f"[SUPERMARIO] All miner attempts finished for room_id={room.room_id}. Computing scores."
+        )
         scores = compute_supermario_scores(room.participants)
         for participant in room.participants:
             participant.score = float(scores.get(participant.hotkey, 0.0))
@@ -122,6 +143,10 @@ class SuperMarioValidatorRunner:
             (participant.steps_count for participant in room.participants), default=0
         )
         await self._update_room(room)
+        bt.logging.info(
+            f"[SUPERMARIO] Final room update sent for room_id={room.room_id}; "
+            f"max_steps={room.step_count}. Uploading scores."
+        )
         await self._sync_scores(room)
 
         ended_at = time.time()
@@ -170,22 +195,42 @@ class SuperMarioValidatorRunner:
             for uid in self.validator.metagraph.uids
             if int(uid) not in exclude_set
         ]
+        bt.logging.info(
+            f"[SUPERMARIO] Discovering participants: eligible_uids={len(uids_to_ping)} "
+            f"excluded={len(exclude_set)}"
+        )
         endpoints = read_endpoints_for_competition(
             self.validator,
             competition_code="supermario",
             uids=uids_to_ping,
         )
         if not endpoints:
+            bt.logging.info(
+                "[SUPERMARIO] No committed supermario endpoints found for eligible miners."
+            )
             return [], {}
+        bt.logging.info(
+            f"[SUPERMARIO] Found {len(endpoints)} committed endpoint(s). Checking responsiveness."
+        )
         responsive_uids = await check_endpoints(self.validator, endpoints, timeout=30)
         if not responsive_uids:
+            bt.logging.info(
+                "[SUPERMARIO] No responsive supermario endpoints passed health checks."
+            )
             return [], {}
+        bt.logging.info(
+            f"[SUPERMARIO] Responsive miners selected: uids={sorted(responsive_uids)}"
+        )
         return sorted(responsive_uids), {uid: endpoints[uid] for uid in responsive_uids}
 
     async def _create_room(self, room: SuperMarioRoomState) -> bool:
         payload = make_create_payload(room)
-        for _ in range(self.max_create_room_attempts):
+        for attempt_idx in range(self.max_create_room_attempts):
             try:
+                bt.logging.info(
+                    f"[SUPERMARIO] Creating backend room attempt {attempt_idx + 1}/"
+                    f"{self.max_create_room_attempts}."
+                )
                 response = await self.backend.create_room("supermario", payload)
             except Exception as err:  # noqa: BLE001
                 bt.logging.warning(
@@ -199,6 +244,9 @@ class SuperMarioValidatorRunner:
             )
             if room_id:
                 room.room_id = str(room_id)
+                bt.logging.info(
+                    f"[SUPERMARIO] Backend room created successfully: room_id={room.room_id}"
+                )
                 return True
             await asyncio.sleep(2)
         return False
@@ -222,6 +270,9 @@ class SuperMarioValidatorRunner:
         reason = "completed" if room.status == "completed" else "aborted"
         payload = make_score_payload(room, reason=reason)
         try:
+            bt.logging.info(
+                f"[SUPERMARIO] Uploading {len(payload['scores'])} score(s) for room_id={room.room_id}."
+            )
             await self.validator.score_store.upload_scores(
                 room_id=room.room_id,
                 competition="supermario",
@@ -245,7 +296,12 @@ class SuperMarioValidatorRunner:
         room: SuperMarioRoomState,
         participant: SuperMarioAttemptState,
     ) -> None:
+        last_progress_log_at = 0.0
         try:
+            bt.logging.info(
+                f"[SUPERMARIO] Starting miner run: uid={participant.uid} "
+                f"hotkey={participant.hotkey} endpoint={participant.endpoint}"
+            )
             run_id = await self._start_run(participant, room)
         except Exception as err:  # noqa: BLE001
             participant.is_finished = True
@@ -257,6 +313,9 @@ class SuperMarioValidatorRunner:
             return
 
         participant.run_id = run_id
+        bt.logging.info(
+            f"[SUPERMARIO] Miner run started: uid={participant.uid} run_id={participant.run_id}"
+        )
         try:
             while True:
                 fetched_steps = await self._fetch_steps(participant)
@@ -273,6 +332,11 @@ class SuperMarioValidatorRunner:
                         [participant],
                         steps_by_hotkey={participant.hotkey: fetched_steps},
                     )
+                    bt.logging.info(
+                        f"[SUPERMARIO] Step update: uid={participant.uid} run_id={participant.run_id} "
+                        f"steps={participant.steps_count} progress={participant.progress_from_start:.1f} "
+                        f"env_score={participant.env_score:.1f} cursor={participant.step_cursor}"
+                    )
 
                 status = await self._fetch_status(participant)
                 if status.current is not None:
@@ -281,7 +345,20 @@ class SuperMarioValidatorRunner:
                     )
                     participant.env_score = float(status.current.score)
                     participant.elapsed_s = float(status.current.elapsed_s)
+                now = time.time()
+                if now - last_progress_log_at >= self.progress_log_interval_sec:
+                    bt.logging.info(
+                        f"[SUPERMARIO] Polling run: uid={participant.uid} run_id={participant.run_id} "
+                        f"state={status.state} steps={participant.steps_count} "
+                        f"progress={participant.progress_from_start:.1f} "
+                        f"env_score={participant.env_score:.1f} elapsed_s={participant.elapsed_s:.1f}"
+                    )
+                    last_progress_log_at = now
                 if status.state in {"succeeded", "failed"}:
+                    bt.logging.info(
+                        f"[SUPERMARIO] Run reached terminal state: uid={participant.uid} "
+                        f"run_id={participant.run_id} state={status.state}"
+                    )
                     break
                 await asyncio.sleep(self.poll_interval_sec)
 
@@ -301,12 +378,18 @@ class SuperMarioValidatorRunner:
                 )
 
             await self._finalize_attempt(participant, status)
+            await self._upload_video_artifact(room, participant, status)
         except Exception as err:  # noqa: BLE001
             participant.is_finished = True
             participant.finish_reason = "error"
             bt.logging.warning(
                 f"[SUPERMARIO] Attempt failed for uid={participant.uid} run_id={participant.run_id}: {err}"
             )
+        bt.logging.info(
+            f"[SUPERMARIO] Attempt finished: uid={participant.uid} run_id={participant.run_id} "
+            f"finish_reason={participant.finish_reason} steps={participant.steps_count} "
+            f"progress={participant.progress_from_start:.1f} env_score={participant.env_score:.1f}"
+        )
         await self._update_room(room, [participant])
 
     async def _finalize_attempt(
@@ -394,6 +477,84 @@ class SuperMarioValidatorRunner:
         steps = [SuperMarioStepPayload.model_validate(step) for step in raw_steps]
         participant.step_cursor = max(participant.step_cursor, next_cursor)
         return steps
+
+    async def _upload_video_artifact(
+        self,
+        room: SuperMarioRoomState,
+        participant: SuperMarioAttemptState,
+        status: SuperMarioRunStatus,
+    ) -> None:
+        video_url = None
+        if status.result is not None:
+            video_url = status.result.video_url or video_url
+        video_url = video_url or status.video_url
+        if not video_url:
+            bt.logging.info(
+                f"[SUPERMARIO] No video artifact reported for uid={participant.uid} run_id={participant.run_id}."
+            )
+            return
+
+        try:
+            video_bytes, mime_type = await self._fetch_video_bytes(
+                participant=participant,
+                video_url=video_url,
+            )
+        except Exception as err:  # noqa: BLE001
+            bt.logging.warning(
+                f"[SUPERMARIO] Failed to fetch video for uid={participant.uid} run_id={participant.run_id}: {err}"
+            )
+            return
+
+        payload = {
+            "validatorKey": room.validator_key,
+            "participant_hotkey": participant.hotkey,
+            "run_id": participant.run_id,
+            "mime_type": mime_type,
+            "mp4_base64": base64.b64encode(video_bytes).decode("ascii"),
+        }
+        try:
+            response = await self.backend.upload_room_video(
+                "supermario", room.room_id, payload
+            )
+        except Exception as err:  # noqa: BLE001
+            bt.logging.warning(
+                f"[SUPERMARIO] Failed to upload video for uid={participant.uid} run_id={participant.run_id}: {err}"
+            )
+            return
+
+        data = response.get("data") if isinstance(response, dict) else None
+        video_id = data.get("id") if isinstance(data, dict) else None
+        if video_id:
+            participant.last_video_id = str(video_id)
+            bt.logging.info(
+                f"[SUPERMARIO] Uploaded final video: uid={participant.uid} run_id={participant.run_id} video_id={participant.last_video_id}"
+            )
+
+    async def _fetch_video_bytes(
+        self,
+        *,
+        participant: SuperMarioAttemptState,
+        video_url: str,
+    ) -> tuple[bytes, str]:
+        endpoint = normalize_endpoint_url(participant.endpoint)
+        request_body = b""
+        headers = generate_header(
+            self.validator.wallet.hotkey,
+            request_body,
+            signed_for=participant.hotkey,
+        )
+        target_url = (
+            video_url
+            if video_url.startswith("http://") or video_url.startswith("https://")
+            else f"{endpoint}{video_url}"
+        )
+        async with httpx.AsyncClient(
+            timeout=max(self.request_timeout_sec, 120)
+        ) as client:
+            response = await client.get(target_url, headers=headers)
+            response.raise_for_status()
+            mime_type = response.headers.get("content-type", "video/mp4").split(";")[0]
+            return response.content, mime_type
 
     async def _request_json(
         self,

--- a/game/plugins/supermario/validator_runner.py
+++ b/game/plugins/supermario/validator_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import time
 from typing import Any
@@ -403,7 +404,13 @@ class SuperMarioValidatorRunner:
         body: dict[str, Any] | None,
     ) -> dict[str, Any]:
         endpoint = normalize_endpoint_url(participant.endpoint)
-        request_body = body if body is not None else b""
+        content: bytes | None = None
+        if body is not None:
+            content = json.dumps(body, separators=(",", ":")).encode("utf-8")
+            request_body: dict[str, Any] | bytes = content
+        else:
+            request_body = b""
+
         headers = generate_header(
             self.validator.wallet.hotkey,
             request_body,
@@ -411,7 +418,11 @@ class SuperMarioValidatorRunner:
         )
         request_kwargs = {"headers": headers}
         if body is not None:
-            request_kwargs["json"] = body
+            request_kwargs["content"] = content
+            request_kwargs["headers"] = {
+                **headers,
+                "Content-Type": "application/json",
+            }
         async with httpx.AsyncClient(timeout=self.request_timeout_sec) as client:
             response = await client.request(
                 method,

--- a/game/plugins/twentyq/validator_runner.py
+++ b/game/plugins/twentyq/validator_runner.py
@@ -18,9 +18,8 @@ from openai import OpenAI
 from game.common.epistula import generate_header
 from game.common.misc import extract_json
 from game.common.targon import normalize_endpoint_url
-from game.core.commitment_reader import read_endpoints
+from game.core.endpoint_resolver import read_endpoints_for_competition
 from game.core.interfaces import AttemptResult, SessionResult
-from game.plugins.codenames.game_types import Competition
 from game.plugins.twentyq.backend_mapper import (
     make_create_payload,
     make_score_payload,
@@ -190,7 +189,11 @@ class TwentyQValidatorRunner:
         ]
         bt.logging.info(f"[20Q] Uids to ping: {uids_to_ping}")
 
-        endpoints = read_endpoints(self.validator, Competition.TWENTYQ, uids_to_ping)
+        endpoints = read_endpoints_for_competition(
+            self.validator,
+            competition_code="twentyq",
+            uids=uids_to_ping,
+        )
         if not endpoints:
             bt.logging.warning("[20Q] No committed endpoints found.")
             return [], {}

--- a/game/providers/backend_client.py
+++ b/game/providers/backend_client.py
@@ -66,3 +66,15 @@ class BackendClient:
                 timeout=self.timeout_sec,
             ) as resp:
                 return await resp.json(content_type=None)
+
+    async def upload_room_video(
+        self, game_code: str, room_id: str, payload: Dict[str, Any]
+    ) -> Any:
+        async with aiohttp.ClientSession() as session:
+            async with session.patch(
+                f"{self.base_url}/api/v1/games/{game_code}/video/{room_id}",
+                json=payload,
+                headers=self._headers(),
+                timeout=max(self.timeout_sec, 120),
+            ) as resp:
+                return await resp.json(content_type=None)

--- a/game/providers/targon_client.py
+++ b/game/providers/targon_client.py
@@ -4,7 +4,7 @@ import asyncio
 import aiohttp
 from game.common.epistula import generate_header
 from game.common.targon import extract_workload_uid, normalize_endpoint_url
-from game import __image_hash__
+from game import get_image_hash_for_competition
 
 
 def _log_yellow_info(message: str) -> None:
@@ -45,12 +45,14 @@ async def _check_image_hash(self, endpoint: str, uid: int | None = None) -> bool
     try:
         url = f"https://api.targon.com/tha/v2/workloads/verify"
         workload_uid = extract_workload_uid(endpoint)
+        competition = getattr(getattr(self, "config", None), "competition", None)
+        expected_image_hash = get_image_hash_for_competition(competition)
         headers = {
             "Authorization": f"Bearer {os.getenv('TARGON_API_KEY')}",
             "Content-Type": "application/json",
         }
         async with aiohttp.ClientSession() as session:
-            payloads = [{"uid": workload_uid, "digest": __image_hash__}]
+            payloads = [{"uid": workload_uid, "digest": expected_image_hash}]
             normalized_url = normalize_endpoint_url(endpoint)
             if workload_uid.startswith("serv-"):
                 payloads.append({"url": normalized_url})
@@ -87,12 +89,12 @@ async def _check_image_hash(self, endpoint: str, uid: int | None = None) -> bool
                 if bool(data.get("verified")):
                     return True
             elif "image_hash" in (data or {}):
-                if data.get("image_hash") == __image_hash__:
+                if data.get("image_hash") == expected_image_hash:
                     return True
 
             bt.logging.info(
                 f"Image digest verification failed for endpoint {endpoint}: "
-                f"workload_uid={workload_uid}"
+                f"workload_uid={workload_uid} competition={competition}"
             )
         return False
     except Exception as e:

--- a/game/storage/weight_state.py
+++ b/game/storage/weight_state.py
@@ -1,0 +1,194 @@
+"""Shared SQLite store for cross-competition weight snapshots."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+import time
+from typing import Any, Optional
+
+import numpy as np
+
+
+class WeightStateStore:
+    def __init__(self, db_path: str):
+        self.db_path = db_path
+        folder = os.path.dirname(db_path)
+        if folder:
+            os.makedirs(folder, exist_ok=True)
+        self._conn: Optional[sqlite3.Connection] = None
+        self._lock = threading.RLock()
+
+    @property
+    def conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            with self._lock:
+                if self._conn is None:
+                    self._conn = sqlite3.connect(
+                        self.db_path, isolation_level=None, check_same_thread=False
+                    )
+                    self._conn.execute("PRAGMA journal_mode=WAL;")
+                    self._conn.execute("PRAGMA synchronous=NORMAL;")
+        return self._conn
+
+    def init(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS competition_weight_snapshots (
+                validator_hotkey TEXT NOT NULL,
+                competition_code TEXT NOT NULL,
+                weight_group TEXT NOT NULL,
+                publish_mechid INTEGER NOT NULL,
+                window_since_ts INTEGER NOT NULL,
+                window_end_ts INTEGER NOT NULL,
+                weights_json TEXT NOT NULL,
+                scores_json TEXT,
+                status TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (validator_hotkey, competition_code)
+            )
+            """)
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS aggregate_weight_publications (
+                validator_hotkey TEXT NOT NULL,
+                weight_group TEXT NOT NULL,
+                publish_mechid INTEGER NOT NULL,
+                published_weights_json TEXT NOT NULL,
+                published_at INTEGER NOT NULL,
+                source_competitions_json TEXT,
+                PRIMARY KEY (validator_hotkey, weight_group)
+            )
+            """)
+        cur.close()
+
+    def upsert_snapshot(
+        self,
+        *,
+        validator_hotkey: str,
+        competition_code: str,
+        weight_group: str,
+        publish_mechid: int,
+        window_since_ts: int,
+        window_end_ts: int,
+        weights: np.ndarray,
+        scores_summary: dict[str, Any],
+        status: str,
+    ) -> None:
+        with self._lock:
+            self.conn.execute(
+                """
+                INSERT INTO competition_weight_snapshots(
+                    validator_hotkey, competition_code, weight_group, publish_mechid,
+                    window_since_ts, window_end_ts, weights_json, scores_json, status,
+                    updated_at
+                )
+                VALUES(?,?,?,?,?,?,?,?,?,?)
+                ON CONFLICT(validator_hotkey, competition_code) DO UPDATE SET
+                    weight_group=excluded.weight_group,
+                    publish_mechid=excluded.publish_mechid,
+                    window_since_ts=excluded.window_since_ts,
+                    window_end_ts=excluded.window_end_ts,
+                    weights_json=excluded.weights_json,
+                    scores_json=excluded.scores_json,
+                    status=excluded.status,
+                    updated_at=excluded.updated_at
+                """,
+                (
+                    validator_hotkey,
+                    competition_code,
+                    weight_group,
+                    int(publish_mechid),
+                    int(window_since_ts),
+                    int(window_end_ts),
+                    json.dumps(np.asarray(weights, dtype=float).tolist()),
+                    json.dumps(scores_summary or {}, sort_keys=True),
+                    status,
+                    int(time.time()),
+                ),
+            )
+
+    def get_fresh_snapshots(
+        self,
+        *,
+        validator_hotkey: str,
+        weight_group: str,
+        freshness_ttl_sec: int,
+    ) -> dict[str, dict[str, Any]]:
+        cutoff = int(time.time()) - int(freshness_ttl_sec)
+        rows = self.conn.execute(
+            """
+            SELECT competition_code, publish_mechid, weights_json, scores_json, status
+            FROM competition_weight_snapshots
+            WHERE validator_hotkey = ? AND weight_group = ? AND updated_at >= ?
+            """,
+            (validator_hotkey, weight_group, cutoff),
+        ).fetchall()
+        snapshots: dict[str, dict[str, Any]] = {}
+        for row in rows:
+            snapshots[str(row[0])] = {
+                "competition_code": str(row[0]),
+                "publish_mechid": int(row[1]),
+                "weights": json.loads(row[2] or "[]"),
+                "scores_summary": json.loads(row[3] or "{}"),
+                "status": str(row[4]),
+            }
+        return snapshots
+
+    def upsert_publication(
+        self,
+        *,
+        validator_hotkey: str,
+        weight_group: str,
+        publish_mechid: int,
+        weights: np.ndarray,
+        source_competitions: list[str],
+    ) -> None:
+        with self._lock:
+            self.conn.execute(
+                """
+                INSERT INTO aggregate_weight_publications(
+                    validator_hotkey, weight_group, publish_mechid,
+                    published_weights_json, published_at, source_competitions_json
+                )
+                VALUES(?,?,?,?,?,?)
+                ON CONFLICT(validator_hotkey, weight_group) DO UPDATE SET
+                    publish_mechid=excluded.publish_mechid,
+                    published_weights_json=excluded.published_weights_json,
+                    published_at=excluded.published_at,
+                    source_competitions_json=excluded.source_competitions_json
+                """,
+                (
+                    validator_hotkey,
+                    weight_group,
+                    int(publish_mechid),
+                    json.dumps(np.asarray(weights, dtype=float).tolist()),
+                    int(time.time()),
+                    json.dumps(source_competitions, sort_keys=True),
+                ),
+            )
+
+    def get_publication(
+        self,
+        *,
+        validator_hotkey: str,
+        weight_group: str,
+    ) -> Optional[dict[str, Any]]:
+        row = self.conn.execute(
+            """
+            SELECT publish_mechid, published_weights_json, published_at,
+                   source_competitions_json
+            FROM aggregate_weight_publications
+            WHERE validator_hotkey = ? AND weight_group = ?
+            """,
+            (validator_hotkey, weight_group),
+        ).fetchone()
+        if row is None:
+            return None
+        return {
+            "publish_mechid": int(row[0]),
+            "weights": json.loads(row[1] or "[]"),
+            "published_at": int(row[2]),
+            "source_competitions": json.loads(row[3] or "[]"),
+        }

--- a/game/validator/score_store.py
+++ b/game/validator/score_store.py
@@ -629,9 +629,9 @@ class ScoreStore:
         try:
             headers = self.signer() if self.signer else {}
             params = {}
+            # Backend sync endpoints return rows with incId > since_id, so send
+            # the last synced id directly. Adding 1 skips the next row.
             since_id = self.max_scores_all_id()
-            if since_id > 0:
-                since_id += 1
             params["since_id"] = since_id
             params["limit"] = 100
             page_num = 0

--- a/tests/unit/plugins/supermario/test_scoring.py
+++ b/tests/unit/plugins/supermario/test_scoring.py
@@ -1,0 +1,41 @@
+from game.plugins.supermario.models import SuperMarioAttemptState
+from game.plugins.supermario.scoring import compute_supermario_scores
+
+
+def test_supermario_scoring_ranks_top_attempt_and_scales_others():
+    leader = SuperMarioAttemptState(
+        uid=1,
+        hotkey="miner-a",
+        endpoint="https://a.example",
+        had_artifacts=True,
+        level_complete=True,
+        progress_from_start=120.0,
+        env_score=500.0,
+        steps_count=100,
+        elapsed_s=10.0,
+        finish_reason="level_complete",
+    )
+    follower = SuperMarioAttemptState(
+        uid=2,
+        hotkey="miner-b",
+        endpoint="https://b.example",
+        had_artifacts=True,
+        progress_from_start=60.0,
+        env_score=300.0,
+        steps_count=110,
+        elapsed_s=12.0,
+        finish_reason="timeout",
+    )
+    failed = SuperMarioAttemptState(
+        uid=3,
+        hotkey="miner-c",
+        endpoint="https://c.example",
+        had_artifacts=False,
+        finish_reason="error",
+    )
+
+    scores = compute_supermario_scores([leader, follower, failed])
+
+    assert scores["miner-a"] == 1.0
+    assert scores["miner-b"] == 0.5
+    assert scores["miner-c"] == 0.0

--- a/tests/unit/plugins/supermario/test_validator_runner.py
+++ b/tests/unit/plugins/supermario/test_validator_runner.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from game.plugins.supermario.models import (
+    SuperMarioAttemptState,
+    SuperMarioRoomState,
+)
+from game.plugins.supermario.protocol import (
+    SuperMarioRunEpisodeResult,
+    SuperMarioRunResult,
+    SuperMarioRunStatus,
+)
+from game.plugins.supermario.validator_runner import SuperMarioValidatorRunner
+
+
+class DummyBackend:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def upload_room_video(self, game_code: str, room_id: str, payload: dict):
+        self.calls.append((game_code, room_id, payload))
+        return {"data": {"id": "video_123"}}
+
+
+def make_runner() -> SuperMarioValidatorRunner:
+    validator = SimpleNamespace(
+        backend_base="https://backend.example",
+        build_signed_headers=lambda: {},
+        wallet=SimpleNamespace(hotkey=SimpleNamespace()),
+    )
+    runner = SuperMarioValidatorRunner(validator)
+    runner.backend = DummyBackend()
+    return runner
+
+
+def test_upload_video_artifact_persists_video_id(monkeypatch):
+    runner = make_runner()
+    room = SuperMarioRoomState(
+        room_id="room_1",
+        validator_key="validator_hotkey",
+        started_at=1,
+    )
+    participant = SuperMarioAttemptState(
+        uid=58,
+        hotkey="miner_hotkey",
+        endpoint="https://miner.example",
+        run_id="run_1",
+    )
+    status = SuperMarioRunStatus(
+        run_id="run_1",
+        state="succeeded",
+        result=SuperMarioRunResult(
+            video_url="/runs/run_1/video",
+            episodes=[SuperMarioRunEpisodeResult(run_id="run_1")],
+        ),
+    )
+
+    async def fake_fetch_video_bytes(*, participant, video_url):
+        assert participant.run_id == "run_1"
+        assert video_url == "/runs/run_1/video"
+        return b"fake-mp4", "video/mp4"
+
+    monkeypatch.setattr(runner, "_fetch_video_bytes", fake_fetch_video_bytes)
+
+    asyncio.run(runner._upload_video_artifact(room, participant, status))
+
+    assert participant.last_video_id == "video_123"
+    assert len(runner.backend.calls) == 1
+    game_code, room_id, payload = runner.backend.calls[0]
+    assert game_code == "supermario"
+    assert room_id == "room_1"
+    assert payload["participant_hotkey"] == "miner_hotkey"
+    assert payload["run_id"] == "run_1"
+    assert payload["mime_type"] == "video/mp4"
+    assert payload["mp4_base64"]
+
+
+def test_upload_video_artifact_skips_when_video_missing(monkeypatch):
+    runner = make_runner()
+    room = SuperMarioRoomState(
+        room_id="room_1",
+        validator_key="validator_hotkey",
+        started_at=1,
+    )
+    participant = SuperMarioAttemptState(
+        uid=58,
+        hotkey="miner_hotkey",
+        endpoint="https://miner.example",
+        run_id="run_1",
+    )
+    status = SuperMarioRunStatus(run_id="run_1", state="succeeded")
+
+    called = False
+
+    async def fake_fetch_video_bytes(*, participant, video_url):
+        nonlocal called
+        called = True
+        return b"", "video/mp4"
+
+    monkeypatch.setattr(runner, "_fetch_video_bytes", fake_fetch_video_bytes)
+
+    asyncio.run(runner._upload_video_artifact(room, participant, status))
+
+    assert participant.last_video_id is None
+    assert called is False
+    assert runner.backend.calls == []

--- a/tests/unit/test_game_codes.py
+++ b/tests/unit/test_game_codes.py
@@ -1,3 +1,4 @@
+from game import __image_hash__, __mario_image_hash__, get_image_hash_for_competition
 from game.core.codes import get_game_code_info, normalize_game_code
 
 
@@ -7,3 +8,9 @@ def test_mario_alias_normalizes_to_supermario():
     assert info.game_code == "supermario"
     assert info.weight_group == "vision"
     assert info.publish_mechid == 1
+
+
+def test_supermario_uses_mario_image_hash():
+    assert get_image_hash_for_competition("supermario") == __mario_image_hash__
+    assert get_image_hash_for_competition("mario") == __mario_image_hash__
+    assert get_image_hash_for_competition("codenames") == __image_hash__

--- a/tests/unit/test_game_codes.py
+++ b/tests/unit/test_game_codes.py
@@ -1,0 +1,9 @@
+from game.core.codes import get_game_code_info, normalize_game_code
+
+
+def test_mario_alias_normalizes_to_supermario():
+    assert normalize_game_code("mario") == "supermario"
+    info = get_game_code_info("mario")
+    assert info.game_code == "supermario"
+    assert info.weight_group == "vision"
+    assert info.publish_mechid == 1

--- a/tests/unit/test_validator_main_mode.py
+++ b/tests/unit/test_validator_main_mode.py
@@ -40,4 +40,5 @@ def test_main_mode_competition_codes_include_all_competitions():
     assert BaseValidatorNeuron._competition_codes_for_main() == [
         "codenames",
         "twentyq",
+        "supermario",
     ]


### PR DESCRIPTION
## Summary

Adds the SuperMario subnet integration as the first vision competition using canonical competition code `supermario` and the shared `vision` weight group publishing to `mechid=1`.

## What Changed

- Adds `game/plugins/supermario` with validator runner, protocol models, backend mapping, and round-relative scoring.
- Extends game metadata and plugin/runtime wiring for `supermario`, including `mario` alias handling and `publish_mechid=1` support.
- Adds shared weight snapshot/publication state for grouped mechid publishing.
- Adds SuperMario deployment profile and README/deploy updates for `--competition supermario`.
- Adds focused unit coverage for SuperMario scoring, validator runner behavior, game-code metadata, and validator main-mode behavior.
- Adds `design/mario` architecture, backend, workflow, and task design docs.
- Fixes backend score sync cursor handling so `incId > since_id` sync does not skip the next score row.

## Validation

- `.venv/bin/python -m compileall game/validator/score_store.py game/plugins/supermario`
- `.venv/bin/python -m pytest tests/unit/plugins/supermario tests/unit/test_game_codes.py tests/unit/test_validator_main_mode.py`
- Live test validator on test netuid 335 with wallet `335/default` created SuperMario rooms, uploaded step/frame updates and final MP4s, synced backend scores, and confirmed `mechid=1` weight row exists on-chain.

